### PR TITLE
feat: bypass Hugo cache when first remote fetch attempt fails

### DIFF
--- a/layouts/partials/utilities/GetResource.html
+++ b/layouts/partials/utilities/GetResource.html
@@ -28,6 +28,11 @@
 {{ $remote := hasPrefix (lower $url) "http" }}
 {{ if $remote }}
     {{ $res = resources.GetRemote $url -}}
+    {{ if not $res }}
+        <!-- Bypass Hugo's cache when first download attempt fails -->
+        {{ $cacheKey := print $url (now.Format "2006-01-02") }}
+        {{ $res = resources.GetRemote $url (dict "key" $cacheKey) -}}
+    {{ end }}
 {{ else }}
     {{ if $page }}
         {{ $res = $page.Resources.Get $url -}}


### PR DESCRIPTION
Hugo caches remote assets to reduce total build time. However, when previously unavailable resources do become available, Hugo does not invalidate it cache. This change introduces a second attempt when the initial fetch operation failed. It overrides the cache key to ensure Hugo connects to the origin server. See https://gohugo.io/functions/resources/getremote/#caching for more details.