### PR TITLE
fix: provide fallback static URL function

### DIFF
--- a/layouts/partials/utilities/GetStaticURL.html
+++ b/layouts/partials/utilities/GetStaticURL.html
@@ -1,10 +1,28 @@
 {{ $url := .url }}
 {{ $result := $url }}
+{{ $major_required := 0 }}
+{{ $minor_required := 112 }}
 
 {{ if not (strings.HasPrefix $url "http") }}
     {{ $lang := site.LanguageCode | default site.Language.Lang }}
     {{ $base :=  strings.TrimSuffix (printf "%s/" $lang) site.Home.RelPermalink }}
-    {{ $result = urls.JoinPath $base $url }}
+    
+    {{/* Test if the (embedded) hugo binary supports urls.JoinPath function (introduced in v0.112.0) */}}
+    {{ $version := split hugo.Version "." }}
+    {{ $major := 0 }}
+    {{ $minor := 0 }}
+    {{ if gt (len $version) 1 }}
+        {{ $major = index $version 0 }}
+        {{ $minor = index $version 1 }}
+    {{ end }}
+
+    {{ if and (ge $major $major_required) (ge $minor $minor_required) }}
+        {{ $result = urls.JoinPath $base $url }}
+    {{ else }}
+        {{ $base = strings.TrimSuffix "/" $base }}
+        {{ $url = strings.TrimPrefix "/" $url }}
+        {{ $result = printf "%s/%s" $base $url }}
+    {{ end }}
 {{ end }}
 
 {{ return $result }}


### PR DESCRIPTION
The function GetStaticURL uses the function `urls.JoinPath` introduced in hugo `v0.112.0`. Certain CMS applications such as CloudCannon use an embedded hugo binary to update a site in real time. The embedded binary cannot be updated to a compatible version at will. This fix introduces a fallback function for such scenarios.