### PR TITLE
feat: support bundling of JavaScript modules

### DIFF
--- a/data/structures/bundle.yml
+++ b/data/structures/bundle.yml
@@ -1,0 +1,49 @@
+comment: >-
+  Bundles a selection of files into a single file.
+arguments:
+  page:
+  match:
+    type: string
+    optional: false
+    comment: Filename or glob pattern of the source file(s) to bundle.
+  filename:
+    type: string
+    optional: false
+    comment: Filename of the target bundle.
+  modules:
+    type: "[]string"
+    optional: true
+    comment: >-
+      Names of the modules to bundle. When `all` is set, a glob pattern
+      consisting of the `basepath`, module name, and default extension is added.
+      Else, a single file is matched.
+  all:
+    type: bool
+    optional: true
+    comment: >-
+      Flag to indicate the module should include a glob pattern to match all
+      nested files.
+  skip-template:
+    type: bool
+    optional: true
+    comment: >-
+      Flag to indicate the matched files should not be processed using
+      `resources.ExecuteAsTemplate`. Set this to true when encountering
+      processing issues due to syntax conflicts.
+  enable-template:
+    type: string
+    optional: true
+    comment: >-
+      Glob pattern to define which source files should be processed as Hugo
+      template. The pattern takes precedence over `skip-template`.
+  basepath:
+    type: string
+    optional: true
+    comment: >-
+      Base path to use when defining a module glob pattern. See `modules` for
+      more details.
+  debugging:
+    type: bool
+    optional: true
+    comment: >-
+      Flag to display which source files are matched for bundling.

--- a/layouts/_partials/utilities/bundlev2.html
+++ b/layouts/_partials/utilities/bundlev2.html
@@ -1,0 +1,100 @@
+{{/* 
+    Copyright © 2022 - 2025 The Hinode Team / Mark Dumay. All rights reserved.
+    Use of this source code is governed by The MIT License (MIT) that can be found in the LICENSE file.
+    Visit gethinode.com/license for more details.
+*/}}
+
+{{/* Initialize arguments */}}
+{{- $args := partial "utilities/InitArgs.html" (dict "structure" "bundle" "args" .) -}}
+{{- if or $args.err $args.warnmsg -}}
+    {{- partial (cond $args.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict 
+        "partial" "utilities/bundlev2.html" 
+        "warnid"  "warn-invalid-arguments"
+        "msg"     "Invalid arguments"
+        "details" ($args.errmsg | append $args.warnmsg)
+        "file"    page.File
+    ) -}}
+{{- end -}}
+
+{{/* Initialize local arguments */}}
+{{- $category := cond (ne $args.category "other") $args.category "" -}}
+{{- $match := $args.match -}}
+{{- $basepath := strings.TrimSuffix "/" $args.basepath -}}
+{{- $ext := trim (path.Ext (trim $match "{}")) "." | default "*js" -}}
+{{- if not $ext -}}
+    {{- errorf "partial [assets/bundlev2.html] - Cannot derive file extension of match pattern: %s" $match -}}
+{{- end -}}
+
+{{/* Initialize return variables */}}
+{{ $bundle := "" }}
+{{ $modBundle := "" }}
+
+{{/* Main code */}}
+{{- if not $args.err -}}
+    {{- if $args.modules -}}
+        {{- $match = trim $match "{}" -}}
+        {{- $matches := slice $match -}}
+        {{- range $index, $mod := $args.modules -}}
+            {{- if $args.all }}
+                {{- $matches = $matches | append (printf "%s/%s/**.%s" $basepath $mod $ext) -}}
+            {{- else -}}
+                {{- $matches = $matches | append (printf "%s/%s.%s" $basepath $mod $ext) -}}
+            {{- end -}}
+        {{- end -}}
+        {{- $match = printf "{%s}" (trim (delimit $matches ",") ",") }}
+    {{- end -}}
+
+    {{ $matches := resources.Match $match }}
+    {{ $templates := cond $args.enableTemplate (resources.Match $args.enableTemplate) dict }}
+    {{ $files := slice }}
+    {{ range $index, $file := $matches }}
+        {{ $add := (dict "name" (strings.TrimSuffix (path.Ext $file.Name) $file.Name) "resource" $file ) }}
+        {{ $files = $files | append $add }}
+    {{ end }}
+
+    {{ $sorted := slice }}
+    {{ $mod := slice }}
+    {{ $files = sort $files "name" }}
+    {{- range $index, $file := $files -}}
+        {{ $process := false }}
+        {{ range $templates }}
+            {{ if eq .Name $file.resource.Name }}
+                {{ $process = true }}
+                {{ break }}
+            {{ end }}
+        {{ end }}
+
+        {{ $res := $file.resource }}
+        {{ if or $process (not $args.skipTemplate )}}
+            {{- $res = $res | resources.ExecuteAsTemplate $res.Name $args.page -}}
+        {{ end }}
+
+        {{ if (hasSuffix (lower $res.Name) ".mjs") }}
+            {{ $mod = $mod | append $res }}
+        {{ else }}    
+            {{ $sorted = $sorted | append $res }}
+        {{ end }}
+    {{- end -}}
+
+    {{- if $args.debugging -}}
+        {{ warnf "Processing pattern for '%s': %s" $args.filename $match }}
+        {{- range $index, $file := union $sorted $mod -}}
+            {{- warnf " - Processing file: %s" $file }}
+        {{- end -}}
+    {{- end -}}
+
+    {{ if gt (len $sorted) 0 }}
+        {{ $bundle = $sorted | resources.Concat $args.filename -}}
+    {{ else }}
+        {{ $bundle = resources.FromString $args.filename "" }}
+    {{ end -}}
+
+    {{ $modFilename := printf "%s.mjs" (strings.TrimSuffix (path.Ext $args.filename) $args.filename) }}
+    {{ if gt (len $mod) 0 }}
+        {{ $modBundle = $mod | resources.Concat $modFilename -}}
+    {{ else }}
+        {{ $modBundle = resources.FromString $modFilename "" }}
+    {{ end -}}
+{{- end -}}
+
+{{- return (dict "bundle" $bundle "module" $modBundle) -}}


### PR DESCRIPTION
Set the file extension to `.mjs` to treat a JavaScript file as a module. The partial is not backwards compatible with bundle.html due to a different return set.