### PR TITLE
fix: resolve Hugo v0.158.0 build failures in multilingual sites

### DIFF
--- a/layouts/_partials/utilities/GetStaticURL.html
+++ b/layouts/_partials/utilities/GetStaticURL.html
@@ -11,7 +11,7 @@
     {{ $url = path.Clean $url }}
     {{ if not $url }}{{ $url = "/" }}{{ end }}
 
-    {{ $lang := site.LanguageCode | default site.Language.Lang }}
+    {{ $lang := site.Language.Lang }}
     {{ $base := strings.TrimSuffix (printf "%s/" $lang) site.Home.RelPermalink }}
 
     {{ $url = partial "utilities/URLJoin.html" (dict "base" $base "path" $url) }}


### PR DESCRIPTION
Replace deprecated site.LanguageCode with site.Language.Lang in GetStaticURL. In Hugo v0.158.0, the language configuration refactor changed site.LanguageCode to return the global languageCode value (e.g. "en-us") instead of the language key (e.g. "en"), breaking the strings.TrimSuffix used to derive the base URL from site.Home.RelPermalink.

site.Language.Lang always returns the language key matching the URL prefix, making this both a correct and backwards-compatible fix.