### PR TITLE
fix: resolve page lookups in foreign render contexts

### DIFF
--- a/layouts/_partials/utilities/GetPage.html
+++ b/layouts/_partials/utilities/GetPage.html
@@ -20,10 +20,21 @@
 {{- if not $isExternal -}}
     {{- $ref = $page.GetPage $url -}}
 
+    {{/* Fallback to a site-wide lookup. Page.GetPage resolves relative
+        references against Hugo's active rendering context (the `page`
+        global), not the receiver page. When content is processed from a
+        foreign render — e.g. an output format whose layout iterates other
+        pages and reads .Plain / .Content / .Summary — the active context
+        is the driving page, and the receiver-based lookup returns nil.
+        site.GetPage is context-independent and finds the page by name. */}}
+    {{ if not $ref }}
+        {{- $ref = site.GetPage $url -}}
+    {{ end }}
+
     {{ if not $ref }}
         {{ $match := partial "utilities/GetStaticURL" (dict "url" $url) }}
         {{ if not (hasSuffix $match "/") }}{{ $match = printf "%s/" $match }}{{ end }}
-        
+
         {{ $matches := where site.AllPages "RelPermalink" "like" (printf "%s$" $match) }}
         {{ if eq (len $matches) 1 }}
             {{ $ref = index $matches 0 }}

--- a/layouts/_partials/utilities/GetStaticURL.html
+++ b/layouts/_partials/utilities/GetStaticURL.html
@@ -12,7 +12,14 @@
     {{ if not $url }}{{ $url = "/" }}{{ end }}
 
     {{ $lang := site.Language.Lang }}
-    {{ $base := strings.TrimSuffix (printf "%s/" $lang) site.Home.RelPermalink }}
+    {{/* site.Home.RelPermalink returns the active output's permalink, so
+        during a non-HTML output render (e.g. a custom searchindex / RSS /
+        custom JSON output) it would inject that output's path here and
+        produce a nonsensical base URL. The HTML output's permalink is the
+        canonical site root and remains stable across render contexts. */}}
+    {{ $homeURL := site.Home.RelPermalink }}
+    {{ with site.Home.OutputFormats.Get "html" }}{{ $homeURL = .RelPermalink }}{{ end }}
+    {{ $base := strings.TrimSuffix (printf "%s/" $lang) $homeURL }}
 
     {{ $url = partial "utilities/URLJoin.html" (dict "base" $base "path" $url) }}
 {{ end }}


### PR DESCRIPTION
## Summary

Two related fixes to mod-utils' page-resolution helpers, plus the 9 dependabot/chore commits already accumulated on develop.

### The new fixes

- **7b96dc3** `fix(GetPage):` fall back to `site.GetPage` for foreign-render contexts.
- **bd6b66e** `fix(GetStaticURL):` pin the base URL to the HTML home permalink (not `site.Home.RelPermalink`, which returns the active output's permalink).

### Why

When a Hugo layout renders content from a foreign page context — e.g. a custom output format whose layout iterates `site.RegularPages` and reads `.Plain` / `.Content` / `.Summary` of other pages — Hugo's `page` global is the *driving* page, not the page whose content is being processed.

- `Page.GetPage(url)` for a relative reference uses Hugo's active rendering context (the `page` global), not the receiver page, so the receiver-based lookup returns nil even when `$page` is correctly passed. The first fix adds `site.GetPage` as a context-independent fallback.
- `GetStaticURL` builds a base URL from `site.Home.RelPermalink`. During a non-HTML output render this returns the active output's permalink (e.g. `/flexsearch-index.json`), producing absurd patterns like `/flexsearch-index.json/introduction/` that match no page in the existing `where site.AllPages "RelPermalink" "like" …` fallback. The second fix pins the base to the HTML home permalink, which is stable across render contexts.

The bug was surfaced by gethinode/mod-flexsearch's new lazyLoad feature (a `searchindex` output format that iterates all pages to build the index data). It manifests as `partial [assets/link.html] - Invalid arguments / Cannot find page or asset: '<name>'` errors on any consuming site with markdown links that use short page names (`[text](introduction)`), because the relative-name resolution chain breaks.

## Verification

- [x] mod-utils exampleSite build clean (`npm test`).
- [x] End-to-end on gethinode.com (which had 47 errors before): patched vendored mod-utils with these fixes + removed a temporary `link.html` override → `npm run build --ignore-scripts` produces **0 errors, exit 0**, `flexsearch-index.json` (120 docs) emitted, `data-search-index=/flexsearch-index.json` wired, core bundle carries the lazy runtime.
- [ ] Reviewer smoke-test: any consuming site that uses a custom output format reading other pages' content (RSS variants, mod-flexsearch with `lazyLoad=true`, mod-llm's llmstxt) should now resolve short-name links correctly without `link.html` errors.

## Coordination

- Without these fixes, mod-flexsearch v4.3.0's `lazyLoad` (gethinode/mod-flexsearch@caaa1fb) produces noisy "Cannot find page or asset" errors on Hinode-docs-heavy sites — exit non-zero, even though the rendered output is correct.
- After this releases, sites using lazy loading should bump `mod-utils/v5` to the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)