### PR TITLE
test: build without Windows hoisted node-linker step (DO NOT MERGE)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    uses: gethinode/.github/.github/workflows/test.yml@v1
+    uses: gethinode/.github/.github/workflows/test.yml@test/no-hoisted
     with:
       package-manager: pnpm
     secrets: inherit


### PR DESCRIPTION
Cross-check for the @v1 cleanup — a module with no cmd-shim, built de-hoisted on Windows via `gethinode/.github@test/no-hoisted`. Draft; will be closed.