### PR TITLE
fix: deprecated snake-case twins overwrite explicit values (camelKey collision)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,24 @@ This is distinct from a value the caller *explicitly* provided as `false`, `0`, 
 (every blueprint key present, typically `null`, plus `_bookshop_name`/`_ordinal`) build clean
 while a genuinely wrong explicit value is still caught.
 
+### Deprecated arguments and camelKey collisions
+
+A deprecated argument (e.g. a legacy snake_case twin of a kebab-case canonical, such as
+`show_preview` next to `show-preview`) is compiled by `ArgsSchema.html` without a `default` or
+`config` — even when the canonical argument it replaces carries one in the global
+`_arguments.yml` definition. A deprecated alias exists only to accept an explicit legacy value
+and emit a warning; defaults belong solely to the canonical replacement. This keeps an unset
+deprecated twin out of the `defaulted` list entirely.
+
+Because hyphens and underscores both camelize to the same key (`show-preview` and `show_preview`
+both become `showPreview`), `Args.html` can visit the same output entry more than once while
+walking the schema. The merge follows a fixed precedence lattice rather than relying on
+iteration order: a caller-provided value on the canonical argument always wins, followed by a
+caller-provided value on the deprecated twin, followed by a defaulted value. A defaulted value
+never overwrites an existing entry, and a value provided through a deprecated argument never
+overwrites a value already provided through its canonical replacement — regardless of which one
+the schema loop happens to visit first.
+
 ### Warnings-first strictness rollout
 
 The following newly detectable problem classes surface as **warnings** (`warnmsg`, `err: false`)

--- a/exampleSite/content/tests/twins.md
+++ b/exampleSite/content/tests/twins.md
@@ -1,0 +1,4 @@
+---
+title: twins
+outputs: ["json"]
+---

--- a/exampleSite/data/structures/test-twin.yml
+++ b/exampleSite/data/structures/test-twin.yml
@@ -1,0 +1,23 @@
+comment: >-
+  Test fixture for the deprecated snake_case twin vs. canonical kebab-case argument
+  camelKey collision: both names camelize to the same key. 'flag-a'/'flag_a' is a fully
+  inline-declared pair (no global argument definition involved). 'show-preview'/'show_preview'
+  mirrors the real-world shape: the canonical argument inherits its type and default from the
+  module's global _arguments.yml, and the deprecated twin inherits the SAME global definition
+  via ArgsSchema's snake->kebab normKey lookup.
+arguments:
+  flag-a:
+    type: bool
+    optional: true
+    default: true
+  flag_a:
+    type: bool
+    optional: true
+    deprecated: 1.0.0
+    alternative: flag-a
+  show-preview:
+    optional: true
+  show_preview:
+    optional: true
+    deprecated: 1.0.0
+    alternative: show-preview

--- a/exampleSite/data/tests/twins.yml
+++ b/exampleSite/data/tests/twins.yml
@@ -1,0 +1,18 @@
+cases:
+  # BUG: the canonical's explicit false is expected to survive, but the deprecated
+  # twin (unset) inherits a default and overwrites it once the twin sorts after the
+  # canonical (underscore > hyphen) in the schema loop.
+  - name: explicit-false-on-canonical
+    structure: test-twin
+    args: {flag-a: "false", show-preview: "false"}
+  - name: unset-uses-canonical-default
+    structure: test-twin
+    args: {}
+  - name: explicit-value-on-deprecated-twin
+    structure: test-twin
+    args: {flag_a: "false", show_preview: "false"}
+  # BUG: both spellings provided; the canonical's explicit false must win over the
+  # deprecated twin's explicit true, regardless of iteration order.
+  - name: both-spellings-provided
+    structure: test-twin
+    args: {flag-a: "false", flag_a: "true", show-preview: "false", show_preview: "true"}

--- a/layouts/_partials/utilities/Args.html
+++ b/layouts/_partials/utilities/Args.html
@@ -343,19 +343,42 @@
         {{ end }}
     {{ end }}
 
-    {{/* validate every schema argument and enforce required ones */}}
+    {{/* validate every schema argument and enforce required ones.
+
+         Two or more declared names (e.g. a kebab-case canonical and its deprecated snake_case
+         twin) can camelize to the same camelKey, so the schema loop below can visit the same
+         $out entry more than once. Map iteration order is sorted by key, which is NOT a
+         reliable precedence signal (it's an accident of "-" < "_" in ASCII) — so track, per
+         camelKey, whether the current entry came from a caller-provided value in $providedKeys
+         and merge under this lattice:
+           - provided-canonical  > provided-deprecated  > defaulted
+           - a defaulted value never overwrites an existing entry (provided or defaulted)
+           - a provided value overwrites a defaulted entry
+           - a provided value from a deprecated node never overwrites an existing provided entry
+             (so a provided canonical always beats a provided deprecated twin, whichever of the
+             two is visited first) */}}
+    {{ $providedKeys := dict }}
     {{ range $key, $node := $schema }}
         {{ $isProvided := isset $normalized $key }}
         {{ $val := index $normalized $key }}
+        {{ $wasProvided := and $isProvided (ne $val nil) }}
         {{ $res := partial "inline/validate-node.html" (dict
             "value" $val "node" $node "path" $key "name" $name
-            "depth" 0 "provided" (and $isProvided (ne $val nil))) }}
+            "depth" 0 "provided" $wasProvided) }}
         {{ range $res.errmsg }}{{ $errmsg = $errmsg | append . }}{{ end }}
         {{ range $res.newmsg }}{{ $newmsg = $newmsg | append . }}{{ end }}
         {{ range $res.warnmsg }}{{ $warnmsg = $warnmsg | append . }}{{ end }}
         {{ range $res.defaulted }}{{ $defaulted = $defaulted | append . }}{{ end }}
         {{ if ne $res.value nil }}
-            {{ $out = merge $out (dict $node.camelKey $res.value) }}
+            {{ $alreadyProvided := index $providedKeys $node.camelKey }}
+            {{ if $wasProvided }}
+                {{ if or (not $alreadyProvided) (not $node.deprecated) }}
+                    {{ $out = merge $out (dict $node.camelKey $res.value) }}
+                    {{ $providedKeys = merge $providedKeys (dict $node.camelKey true) }}
+                {{ end }}
+            {{ else if not $alreadyProvided }}
+                {{ $out = merge $out (dict $node.camelKey $res.value) }}
+            {{ end }}
         {{ end }}
 
         {{ $skip := false }}

--- a/layouts/_partials/utilities/ArgsSchema.html
+++ b/layouts/_partials/utilities/ArgsSchema.html
@@ -12,6 +12,13 @@
     "reflects" field: a []string of raw package-qualified Go reflect-type names (e.g.
     "template.HTML") declared in the data files, matched verbatim against printf "%T" at
     validation time.
+
+    A node carrying "deprecated" never stores "default" or "config", regardless of whether that
+    default/config would have come from the global _arguments.yml definition (via the snake->kebab
+    normKey lookup) or from an inline override in the structure file. A deprecated alias exists
+    only to accept an explicit legacy value and warn the caller; defaults belong solely to the
+    canonical replacement argument. This also keeps a deprecated twin out of Args.html's
+    "defaulted" list when the caller leaves it unset.
 */}}
 
 {{ define "_partials/inline/camel-key.html" }}
@@ -162,8 +169,13 @@
         }}
         {{ if $children }}{{ $node = merge $node (dict "children" $children "udtType" $udtType) }}{{ end }}
         {{ if $reflects }}{{ $node = merge $node (dict "reflects" $reflects) }}{{ end }}
-        {{ if ne $def.default nil }}{{ $node = merge $node (dict "default" $def.default) }}{{ end }}
-        {{ with $def.config }}{{ $node = merge $node (dict "config" .) }}{{ end }}
+        {{/* a deprecated argument never carries a default or a config lookup — see the header
+             doc. This applies whether "default"/"config" were inherited from the global
+             definition via the normKey lookup above or declared inline on this node. */}}
+        {{ if not $def.deprecated }}
+            {{ if ne $def.default nil }}{{ $node = merge $node (dict "default" $def.default) }}{{ end }}
+            {{ with $def.config }}{{ $node = merge $node (dict "config" .) }}{{ end }}
+        {{ end }}
         {{ with $def.options }}{{ $node = merge $node (dict "options" .) }}{{ end }}
         {{ if isset $def "position" }}{{ $node = merge $node (dict "position" $def.position) }}{{ end }}
         {{ with $def.group }}{{ $node = merge $node (dict "group" (slice | append .)) }}{{ end }}

--- a/tests/golden/twins.json
+++ b/tests/golden/twins.json
@@ -2,8 +2,8 @@
   "both-spellings-provided": {
     "args": {
       "args": {
-        "flagA": true,
-        "showPreview": true
+        "flagA": false,
+        "showPreview": false
       },
       "defaulted": [],
       "err": false,
@@ -17,12 +17,12 @@
       "default": [],
       "err": false,
       "errmsg": [],
-      "flag-a": true,
-      "flagA": true,
-      "flag_a": true,
-      "show-preview": true,
-      "showPreview": true,
-      "show_preview": true,
+      "flag-a": false,
+      "flagA": false,
+      "flag_a": false,
+      "show-preview": false,
+      "showPreview": false,
+      "show_preview": false,
       "warnmsg": [
         "[test-twin] argument 'flag_a': deprecated in v1.0.0, use 'flag-a' instead",
         "[test-twin] argument 'show_preview': deprecated in v1.0.0, use 'show-preview' instead"
@@ -33,27 +33,23 @@
     "args": {
       "args": {
         "flagA": false,
-        "showPreview": true
+        "showPreview": false
       },
-      "defaulted": [
-        "show_preview"
-      ],
+      "defaulted": [],
       "err": false,
       "errmsg": [],
       "warnmsg": []
     },
     "initargs": {
-      "default": [
-        "show_preview"
-      ],
+      "default": [],
       "err": false,
       "errmsg": [],
       "flag-a": false,
       "flagA": false,
       "flag_a": false,
-      "show-preview": true,
-      "showPreview": true,
-      "show_preview": true,
+      "show-preview": false,
+      "showPreview": false,
+      "show_preview": false,
       "warnmsg": []
     }
   },
@@ -101,8 +97,7 @@
       },
       "defaulted": [
         "flag-a",
-        "show-preview",
-        "show_preview"
+        "show-preview"
       ],
       "err": false,
       "errmsg": [],
@@ -111,8 +106,7 @@
     "initargs": {
       "default": [
         "flag-a",
-        "show-preview",
-        "show_preview"
+        "show-preview"
       ],
       "err": false,
       "errmsg": [],

--- a/tests/golden/twins.json
+++ b/tests/golden/twins.json
@@ -1,0 +1,128 @@
+{
+  "both-spellings-provided": {
+    "args": {
+      "args": {
+        "flagA": true,
+        "showPreview": true
+      },
+      "defaulted": [],
+      "err": false,
+      "errmsg": [],
+      "warnmsg": [
+        "[test-twin] argument 'flag_a': deprecated in v1.0.0, use 'flag-a' instead",
+        "[test-twin] argument 'show_preview': deprecated in v1.0.0, use 'show-preview' instead"
+      ]
+    },
+    "initargs": {
+      "default": [],
+      "err": false,
+      "errmsg": [],
+      "flag-a": true,
+      "flagA": true,
+      "flag_a": true,
+      "show-preview": true,
+      "showPreview": true,
+      "show_preview": true,
+      "warnmsg": [
+        "[test-twin] argument 'flag_a': deprecated in v1.0.0, use 'flag-a' instead",
+        "[test-twin] argument 'show_preview': deprecated in v1.0.0, use 'show-preview' instead"
+      ]
+    }
+  },
+  "explicit-false-on-canonical": {
+    "args": {
+      "args": {
+        "flagA": false,
+        "showPreview": true
+      },
+      "defaulted": [
+        "show_preview"
+      ],
+      "err": false,
+      "errmsg": [],
+      "warnmsg": []
+    },
+    "initargs": {
+      "default": [
+        "show_preview"
+      ],
+      "err": false,
+      "errmsg": [],
+      "flag-a": false,
+      "flagA": false,
+      "flag_a": false,
+      "show-preview": true,
+      "showPreview": true,
+      "show_preview": true,
+      "warnmsg": []
+    }
+  },
+  "explicit-value-on-deprecated-twin": {
+    "args": {
+      "args": {
+        "flagA": false,
+        "showPreview": false
+      },
+      "defaulted": [
+        "flag-a",
+        "show-preview"
+      ],
+      "err": false,
+      "errmsg": [],
+      "warnmsg": [
+        "[test-twin] argument 'flag_a': deprecated in v1.0.0, use 'flag-a' instead",
+        "[test-twin] argument 'show_preview': deprecated in v1.0.0, use 'show-preview' instead"
+      ]
+    },
+    "initargs": {
+      "default": [
+        "flag-a",
+        "show-preview"
+      ],
+      "err": false,
+      "errmsg": [],
+      "flag-a": false,
+      "flagA": false,
+      "flag_a": false,
+      "show-preview": false,
+      "showPreview": false,
+      "show_preview": false,
+      "warnmsg": [
+        "[test-twin] argument 'flag_a': deprecated in v1.0.0, use 'flag-a' instead",
+        "[test-twin] argument 'show_preview': deprecated in v1.0.0, use 'show-preview' instead"
+      ]
+    }
+  },
+  "unset-uses-canonical-default": {
+    "args": {
+      "args": {
+        "flagA": true,
+        "showPreview": true
+      },
+      "defaulted": [
+        "flag-a",
+        "show-preview",
+        "show_preview"
+      ],
+      "err": false,
+      "errmsg": [],
+      "warnmsg": []
+    },
+    "initargs": {
+      "default": [
+        "flag-a",
+        "show-preview",
+        "show_preview"
+      ],
+      "err": false,
+      "errmsg": [],
+      "flag-a": true,
+      "flagA": true,
+      "flag_a": true,
+      "show-preview": true,
+      "showPreview": true,
+      "show_preview": true,
+      "warnmsg": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Structures that declare a kebab-case argument plus a deprecated snake_case
twin (e.g. `show-preview` + `show_preview`, a common pattern across Hinode)
silently overwrote an explicit value with the twin's inherited default.

### Defect

Both names camelize to the same `camelKey` (`showPreview`). In
`ArgsSchema.html`, the deprecated twin's node inherited the canonical
argument's global definition — including its `default` — via the
snake→kebab `normKey` lookup against the module's global `_arguments.yml`.
In `Args.html`'s schema loop, Go template map iteration visits keys in
sorted order, and the twin sorts *after* the canonical (`_` > `-` in ASCII).
Since the loop unconditionally overwrote `$out[$node.camelKey]` on every
non-nil result, the twin's defaulted value clobbered the caller's explicit
`show-preview=false`, turning it into `true`. The same unconditional
last-write-wins also flipped results whenever *both* spellings were
explicitly provided, regardless of intended precedence. Both the strict
`Args.html` path and the `InitArgs.html` compatibility shim were affected
(the shim delegates to `Args.html`).

### Fix (two layers)

1. **`ArgsSchema.html` (compile-node):** a node carrying `deprecated` never
   stores `default` or `config` — whether inherited from the global
   definition via the `normKey` lookup or declared inline. A deprecated
   alias exists only to accept an explicit legacy value and warn; defaults
   belong to the canonical replacement. This also keeps a deprecated twin
   out of `defaulted` when the caller leaves it unset.
2. **`Args.html` (main schema loop):** the camelKey merge is now
   precedence-safe and order-independent via a small `providedKeys`
   tracking dict: `provided-canonical > provided-deprecated > defaulted`. A
   defaulted value never overwrites an existing entry; a provided value
   overwrites a defaulted entry; a provided value from a deprecated node
   never overwrites an existing provided entry.

### Golden evidence

New `twins` test group (`exampleSite/data/structures/test-twin.yml` +
`exampleSite/data/tests/twins.yml`) covers an inline-declared twin pair
(`flag-a`/`flag_a`) and a pair that inherits its default from the module's
global `_arguments.yml` (`show-preview`/`show_preview`, verified via grep
to carry `default: true`).

Pinned (buggy) golden — `explicit-false-on-canonical`:

```json
"showPreview": true,          // should be false
"defaulted": ["show_preview"] // twin should never default
```

Fixed golden — same case:

```json
"showPreview": false,
"defaulted": []
```

`both-spellings-provided` (kebab `false` + snake `true`) flips from
`flagA/showPreview: true` (twin's explicit value wins, wrong) to `false`
(canonical wins, correct) on both the `args` (strict) and `initargs` (shim)
paths.

`unset-uses-canonical-default` keeps `flagA`/`showPreview` at their
canonical default (`true`) but the `defaulted` list drops `show_preview`,
leaving only the canonical `show-preview`/`flag-a` entries.

`explicit-value-on-deprecated-twin` (deprecation warning + explicit twin
value honored) is unchanged before/after — it was already accidentally
correct, and is now correct by design via the precedence lattice.

**Other-golden drift:** none. `git diff --stat tests/golden/` after the fix
touches only `twins.json`; all 12 pre-existing golden groups
(bookshop, casting, child, defaults, envelope, frontmatter, inittypes,
nesting, options, positional, required, schema) are byte-identical.

## Test plan

- [x] `pnpm test:update && pnpm test` — 13/13 golden groups pass
- [x] Inspected the characterization golden (commit 1) to confirm it pins
      the exact defect described above
- [x] Inspected the fixed golden (commit 2) to confirm correct behavior on
      all four twin cases, on both the strict and shim paths
- [x] Diffed every other golden file — zero unexpected drift
- [x] README.md updated with a new "Deprecated arguments and camelKey
      collisions" subsection under "Argument validation"

This ships as v6.0.1 (bug fix, no API change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
