### PR TITLE
feat(structures): add testimonials icon and video media-id members

### DIFF
--- a/data/structures/_types.yml
+++ b/data/structures/_types.yml
@@ -94,6 +94,7 @@ types:
     provider:
     account:
     id:
+    media-id:
     autoplay:
     query-args:
   testimonials:
@@ -101,6 +102,7 @@ types:
       content:
       client:
       link:
+      icon:
   client:
     contact:
     role:

--- a/exampleSite/data/structures/_types.yml
+++ b/exampleSite/data/structures/_types.yml
@@ -98,6 +98,7 @@ types:
     provider:
     account:
     id:
+    media-id:
     autoplay:
     query-args:
   testimonials:
@@ -105,6 +106,7 @@ types:
       content:
       client:
       link:
+      icon:
   client:
     contact:
     role:


### PR DESCRIPTION
## Summary

Two additive members reported by the mod-blocks mod-utils v6 adoption (hinode
`wave3-blocks-report.md`, structure-gap section) as missing from the shared
types in `data/structures/_types.yml`:

- `testimonials[].icon` — mod-blocks `assets/testimonial-carousel.html` reads
  `$item.icon` for every testimonial and forwards it to
  `assets/testimonial.html`, but the shared `testimonials` type only declared
  `logo`/`content`/`client`/`link`, so Bookshop-validated testimonials content
  using `icon` triggered `unsupported attribute 'icon'` warnings. The global
  `icon` argument already exists in `_arguments.yml`.
- `video.media-id` — hinode's `assets/video.html` resolves the clip ID via
  `$args.mediaId`, falling back to `$args.id` only when `media-id` is absent,
  and mod-blocks `video-message.hugo.html` builds its video dict from
  `media_id` / `"media-id"`. The shared `video` type only declared `id`. `id`
  is kept (additive change only, no removal) since `assets/video.html` still
  falls back to it. The global `media-id` argument already exists in
  `_arguments.yml`.

The `exampleSite/data/structures/_types.yml` shadow copy is updated identically
above its test-only marker, per the file's own sync obligation.

## Test plan

- [x] Verified both members against the consuming partials in the hinode and
      mod-blocks clones (`assets/testimonial-carousel.html`,
      `assets/video.html`, `video-message.hugo.html`)
- [x] Confirmed `icon` and `media-id` already have global argument definitions
      in `data/structures/_arguments.yml` (no new global argument needed)
- [x] `pnpm test` — golden check passed (13 groups), zero drift; no existing
      test fixture exercises the `testimonials` or `video` shared types

🤖 Generated with [Claude Code](https://claude.com/claude-code)