### PR TITLE
feat(structures): add video color member

### DIFF
--- a/data/structures/_types.yml
+++ b/data/structures/_types.yml
@@ -97,6 +97,7 @@ types:
     media-id:
     autoplay:
     query-args:
+    color:
   testimonials:
     - logo:
       content:

--- a/exampleSite/data/structures/_types.yml
+++ b/exampleSite/data/structures/_types.yml
@@ -101,6 +101,7 @@ types:
     media-id:
     autoplay:
     query-args:
+    color:
   testimonials:
     - logo:
       content:


### PR DESCRIPTION
Adds the `color` member to the shared `video` type, consumed by mod-blocks' video-message component. Additive; goldens unchanged (13/13 green). Companion to #336, surfaced by the Hinode v3 H1 warnings inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)