### PR TITLE
feat(structures): add links outline member

### DIFF
--- a/data/structures/_types.yml
+++ b/data/structures/_types.yml
@@ -70,6 +70,7 @@ types:
       icon:
       force:
       order:
+      outline:
   messages:
     - title:
       icon:

--- a/exampleSite/data/structures/_types.yml
+++ b/exampleSite/data/structures/_types.yml
@@ -74,6 +74,7 @@ types:
       icon:
       force:
       order:
+      outline:
   messages:
     - title:
       icon:


### PR DESCRIPTION
Adds the `outline` member to the shared `links` type (global argument already defined). Additive; goldens 13/13 green. Companion to #336/#337; clears the last shared-type warning class from the Hinode v3 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)