### PR TITLE
feat(structures): add elements link member

### DIFF
--- a/data/structures/_types.yml
+++ b/data/structures/_types.yml
@@ -63,6 +63,7 @@ types:
       image:
       mode:
       content:
+      link:
   links:
     - title:
       url:

--- a/exampleSite/data/structures/_types.yml
+++ b/exampleSite/data/structures/_types.yml
@@ -67,6 +67,7 @@ types:
       image:
       mode:
       content:
+      link:
   links:
     - title:
       url:


### PR DESCRIPTION
Adds the `link` member to the shared `elements` type (global argument exists). Additive; goldens 13/13 green. Companion to #336/#337/#338; clears theme-agency's two residual warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)