### PR TITLE
fix(arguments): drop the wrap/data-table incompatibility note

### DIFF
--- a/data/structures/_arguments.yml
+++ b/data/structures/_arguments.yml
@@ -1688,8 +1688,7 @@ arguments:
     type: bool
     optional: true
     comment: >-
-      Toggle the last column to wrap to a new row on smaller devices. This
-      setting is not compatible with data tables.
+      Toggle the last column to wrap to a new row on smaller devices.
   wrapper:
     type: string
     optional: true


### PR DESCRIPTION
The `wrap` argument's comment claimed *"This setting is not compatible with data tables."* That is no longer true: Hinode now renders a wrapped data table uniformly and mod-simple-datatables applies the wrapped layout through simple-datatables' `tableRender` hook, so `wrap` combines with `sortable`, `paginate` and `searchable`.

Typed `fix` rather than `docs` deliberately: the comment feeds the generated argument documentation, so it needs a release (v6.4.0 → v6.4.1) to reach downstream sites. The companion PRs will then pick up the bump.

Companion to gethinode/hinode#2018 and gethinode/mod-simple-datatables#277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)