### PR TITLE
fix(arguments): stop re-validating absent schema keys on every Args call

### DIFF
--- a/layouts/_partials/utilities/Args.html
+++ b/layouts/_partials/utilities/Args.html
@@ -362,9 +362,20 @@
         {{ $isProvided := isset $normalized $key }}
         {{ $val := index $normalized $key }}
         {{ $wasProvided := and $isProvided (ne $val nil) }}
-        {{ $res := partial "inline/validate-node.html" (dict
-            "value" $val "node" $node "path" $key "name" $name
-            "depth" 0 "provided" $wasProvided) }}
+        {{ $res := dict }}
+        {{ if $isProvided }}
+            {{ $res = partial "inline/validate-node.html" (dict
+                "value" $val "node" $node "path" $key "name" $name
+                "depth" 0 "provided" $wasProvided) }}
+        {{ else }}
+            {{/* an absent key's validation is a constant per (structure, bookshop, child, key):
+                 it reads only the compiled node and site.Params (via inline/site-param.html for
+                 'config:' defaults) — never page state. partialCached is per-language, so
+                 language-scoped site.Params lookups stay correct. */}}
+            {{ $res = partialCached "inline/validate-node.html" (dict
+                "value" $val "node" $node "path" $key "name" $name
+                "depth" 0 "provided" $wasProvided) (or $structure "") (or $bookshop "") (or $child "") $key }}
+        {{ end }}
         {{ range $res.errmsg }}{{ $errmsg = $errmsg | append . }}{{ end }}
         {{ range $res.newmsg }}{{ $newmsg = $newmsg | append . }}{{ end }}
         {{ range $res.warnmsg }}{{ $warnmsg = $warnmsg | append . }}{{ end }}

--- a/layouts/_partials/utilities/Args.html
+++ b/layouts/_partials/utilities/Args.html
@@ -368,13 +368,9 @@
                 "value" $val "node" $node "path" $key "name" $name
                 "depth" 0 "provided" $wasProvided) }}
         {{ else }}
-            {{/* an absent key's validation is a constant per (structure, bookshop, child, key):
-                 it reads only the compiled node and site.Params (via inline/site-param.html for
-                 'config:' defaults) — never page state. partialCached is per-language, so
-                 language-scoped site.Params lookups stay correct. */}}
-            {{ $res = partialCached "inline/validate-node.html" (dict
-                "value" $val "node" $node "path" $key "name" $name
-                "depth" 0 "provided" $wasProvided) (or $structure "") (or $bookshop "") (or $child "") $key }}
+            {{/* an absent key's validation is a constant per (structure, bookshop, child, key);
+                 read the outcome precomputed in the cached ArgsSchema.html envelope */}}
+            {{ $res = index $compiled.absent $key }}
         {{ end }}
         {{ range $res.errmsg }}{{ $errmsg = $errmsg | append . }}{{ end }}
         {{ range $res.newmsg }}{{ $newmsg = $newmsg | append . }}{{ end }}

--- a/layouts/_partials/utilities/ArgsSchema.html
+++ b/layouts/_partials/utilities/ArgsSchema.html
@@ -264,4 +264,18 @@
     {{ end }}
 {{ end }}
 
-{{ return (dict "schema" $schema "positions" $positions "err" (gt (len $errmsg) 0) "errmsg" $errmsg) }}
+{{/* precompute each key's absent-value validation outcome (value nil, provided false): it is a
+     constant per (structure, bookshop, child, key), reading only the compiled node and
+     site.Params (via inline/site-param.html for 'config:' defaults) — never page state.
+     Args.html indexes this map instead of re-validating absent keys on every call. This makes
+     the envelope depend on site.Params in addition to the site's data files; partialCached is
+     per-language, so language-scoped lookups stay correct. */}}
+{{ $absent := dict }}
+{{ range $key, $node := $schema }}
+    {{ $res := partial "inline/validate-node.html" (dict
+        "value" nil "node" $node "path" $key "name" $name
+        "depth" 0 "provided" false) }}
+    {{ $absent = merge $absent (dict $key $res) }}
+{{ end }}
+
+{{ return (dict "schema" $schema "positions" $positions "absent" $absent "err" (gt (len $errmsg) 0) "errmsg" $errmsg) }}

--- a/tests/golden/schema.json
+++ b/tests/golden/schema.json
@@ -1,6 +1,71 @@
 {
   "bookshop-blueprint": {
     "schema": {
+      "absent": {
+        "_bookshop_name": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "_ordinal": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "heading": {
+          "defaulted": [
+            "heading.align",
+            "heading.arrangement",
+            "heading.size"
+          ],
+          "errmsg": [],
+          "newmsg": [],
+          "value": {
+            "align": "start",
+            "arrangement": "above",
+            "size": 4
+          },
+          "warnmsg": []
+        },
+        "id": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "link_type": {
+          "defaulted": [
+            "link_type"
+          ],
+          "errmsg": [],
+          "newmsg": [],
+          "value": "button",
+          "warnmsg": []
+        },
+        "show_more": {
+          "defaulted": [
+            "show_more"
+          ],
+          "errmsg": [],
+          "newmsg": [],
+          "value": false,
+          "warnmsg": []
+        },
+        "width": {
+          "defaulted": [
+            "width"
+          ],
+          "errmsg": [],
+          "newmsg": [],
+          "value": 8,
+          "warnmsg": []
+        }
+      },
       "err": false,
       "errmsg": [],
       "positions": {},
@@ -251,6 +316,29 @@
   },
   "child-merge": {
     "schema": {
+      "absent": {
+        "hook": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "ratio": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "title": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        }
+      },
       "err": false,
       "errmsg": [],
       "positions": {},
@@ -301,6 +389,22 @@
   },
   "compile-errors": {
     "schema": {
+      "absent": {
+        "bogus-typed": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "root-node": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        }
+      },
       "err": true,
       "errmsg": [
         "schema: unknown type 'no-such-type' for 'test-cycle.bogus-typed'",
@@ -359,6 +463,37 @@
   },
   "nested-structure": {
     "schema": {
+      "absent": {
+        "heading": {
+          "defaulted": [
+            "heading.align",
+            "heading.arrangement",
+            "heading.size"
+          ],
+          "errmsg": [],
+          "newmsg": [],
+          "value": {
+            "align": "start",
+            "arrangement": "above",
+            "size": 4
+          },
+          "warnmsg": []
+        },
+        "locations": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": [],
+          "warnmsg": []
+        },
+        "title": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        }
+      },
       "err": false,
       "errmsg": [],
       "positions": {},
@@ -699,6 +834,36 @@
   },
   "positions": {
     "schema": {
+      "absent": {
+        "flag": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "kind": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "name": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "partial-only": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        }
+      },
       "err": false,
       "errmsg": [],
       "positions": {
@@ -765,6 +930,50 @@
   },
   "scalar-structure": {
     "schema": {
+      "absent": {
+        "count": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "data": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "flag": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "items-list": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "label": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        },
+        "ratio-value": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        }
+      },
       "err": false,
       "errmsg": [],
       "positions": {},


### PR DESCRIPTION
# fix(arguments): stop re-validating absent schema keys on every Args call

## Problem

`utilities/Args.html` validates every schema key on every invocation, calling
`partial "inline/validate-node.html"` even for keys the caller did not provide. For an
absent key the outcome is a constant per (structure, bookshop, child, key): the validation
reads only the compiled schema node and `site.Params` (via `inline/site-param.html` for
`config:` defaults) — never page state. On a content-heavy site, `Args.html` runs thousands
of times and most schema keys are absent in any given call, so this constant work dominates
the partial's CPU cost.

## Change

Two commits, independently droppable:

1. **`43aee9b` — cache absent-key validation per schema key.** Split the main schema loop:
   provided keys keep the plain `partial` call; absent keys go through `partialCached`
   keyed by `(structure, bookshop, child, key)`.
2. **`3375768` — precompute absent-key outcomes in the schema envelope.** Fold each key's
   absent-value validation outcome (value nil, provided false) into the `ArgsSchema.html`
   envelope, which `Args.html` already retrieves through `partialCached` keyed by
   (structure, bookshop, child). The absent branch from commit 1 becomes a plain map index
   (`index $compiled.absent $key`), removing even the per-key `partialCached` lookup.
   The golden fixture `tests/golden/schema.json` gains the additive `absent` envelope
   member (209 inserted lines, zero deletions); all Args result groups are byte-identical.

The loop structure, visit order (sorted schema keys), merge lattice
(provided-canonical > provided-deprecated > defaulted), message slices, and the
`defaulted`-path order are unchanged by construction — only where the absent-key outcome
comes from changes.

A fuller variant (iterate only provided keys and merge a precomputed "rest" wholesale) was
evaluated and rejected: it reorders the `defaulted` list relative to provided keys' child
defaults and would include defaulted paths for keys the caller actually provided, forcing
per-key filtering anyway.

## Safety argument

- An absent-key validation is a pure function of the compiled node and `site.Params`:
  the only external reads in `inline/validate-node.html` on the absent path are the node
  itself and `inline/site-param.html` (`config:` defaults). No page variables, no context.
- Hugo's `partialCached` cache is per language, so language-scoped `site.Params` lookups
  (multilingual `config:` defaults) cannot leak across languages. Verified on the
  trilingual hinode exampleSite (EN/FR/NL).
- Deprecated schema nodes never carry `default`/`config` (enforced by `ArgsSchema.html`),
  so precomputed absent outcomes cannot disturb the deprecated-twin merge lattice.
- `ArgsSchema.html`'s envelope now depends on `site.Params` in addition to the site's data
  files; its header comment is updated accordingly.

## Gate evidence (hinode exampleSite @ 18ff4f6e, hugo 0.164.0)

Byte-diff gate, `hugo --gc --minify -s exampleSite`, stock (v6.5.0 from module cache) vs
candidate (`HUGO_MODULE_REPLACEMENTS` pointing at this branch), two candidate runs:

```
$ diff -rq $SNAP/run-a $SNAP/run-b        # candidate run-vs-run
(empty — rc=0)

$ diff -rq $SNAP/run-a $SNAP/stock/run-a  # candidate vs stock
Files .../run-a/en/index.xml and .../stock/run-a/en/index.xml differ
```

The single `en/index.xml` diff is the known pre-existing intermittent `.Content` race
(nondeterministic `UID` counter in RSS-embedded tab markup: `nav-UID-5` vs `nav-UID-1`);
it is on the program's allowlist. All builds: exit 0, zero ERROR lines, page counts
98 EN / 26 FR / 24 NL, WARN sets byte-identical to the stock baseline.

The step-1-only intermediate state passed the same gate independently (only the
allowlisted `en/index.xml` differed), so commit 2 can be dropped without re-verification.

Test suite: `pnpm test` (golden check, 13 groups) passes on both commits; commit 2
regenerates `tests/golden/schema.json` via `pnpm test:update`.

## Measurements

Protocol: hinode exampleSite @ 18ff4f6e, `hugo --gc --minify -s exampleSite`, Apple M1 Pro
(10 cores, 32 GB), repo-pinned hugo v0.164.0 extended. 3 warm-up builds until wall stabilized,
then 3 timed runs per variant, medians reported, no other load (driver-serialized).

| Variant | Median user CPU | Median wall (`Total in`) |
| --- | --- | --- |
| stock (mod-utils v6.5.0) | 38.69 s (38.48/38.69/39.32) | 14.75 s (14.50/14.75/14.88) |
| this branch (steps 1+2) | 33.43 s (33.23/33.63/33.43) | 13.10 s (13.23/13.06/13.10) |
| **delta** | **−13.6% CPU** | **−11.2% wall** |

DoD floor was ≥8% CPU reduction; measured −13.6%.

## Step-2 status

Implemented and gate-verified (this PR contains both commits). The envelope fold
supersedes the step-1 `partialCached` mechanism while keeping it as a droppable
intermediate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
