### PR TITLE
feat: Store dual-write for AddModule and pure GetBaseURL helper (render-once D1)

### DIFF
--- a/layouts/_partials/utilities/AddModule.html
+++ b/layouts/_partials/utilities/AddModule.html
@@ -1,13 +1,47 @@
+{{/*
+    Registers a module as a dependency of the given page. The page's stylesheet and script
+    handlers include the assets of registered modules when rendering the page.
+
+    The accumulated "dependencies" slice is written to both the page's Scratch and Store.
+    The Scratch entry is the current home consumed by existing themes; the Store entry is its
+    successor, as Hugo guarantees Store values set during content rendering remain available
+    to templates rendered afterwards. The dual-write is transitional: consumers migrate to the
+    Store entry, after which the Scratch entry will be removed in the next major release.
+
+    Registration must land on the page that owns the content being rendered. Relying on the
+    global page context is unreliable: when a foreign render (such as an RSS feed or search
+    index touching .Content) triggers the content render, the global context is the foreign
+    page. Callers should therefore always pass the owning page explicitly. Omitting the page
+    argument is deprecated: it falls back to the global page context for one release, after
+    which the argument becomes required. The deprecation warning is gated behind the site
+    parameter `debugging.showDeprecations` while known callers still omit the argument, so
+    that site authors are not warned about calls they cannot fix themselves.
+
+    Arguments:
+      module  (string, required)  name of the module to register, e.g. "lightbox"
+      page    (page)              the page to register the module on; omitting it is
+                                  deprecated and falls back to the global page context
+*/}}
+
 {{- $page := .page -}}
 {{- if not $page -}}
+	{{- if site.Params.debugging.showDeprecations -}}
+		{{- partial "utilities/LogWarn.html" (dict
+			"partial" "utilities/AddModule.html"
+			"warnid"  "warn-deprecated-arguments"
+			"msg"     "Argument 'page' is missing: deprecated, pass the owning page explicitly"
+			"file"    page.File
+		) -}}
+	{{- end -}}
 	{{- $page = page -}}
 {{- end -}}
 {{ with .module }}
-	{{- $dependencies := $page.Scratch.Get "dependencies" -}}
+	{{- $dependencies := or ($page.Scratch.Get "dependencies") ($page.Store.Get "dependencies") -}}
 	{{- if reflect.IsSlice $dependencies -}}
 		{{- $dependencies = $dependencies | append . | uniq -}}
 	{{ else }}
 		{{- $dependencies = slice . -}}
 	{{ end }}
 	{{- $page.Scratch.Set "dependencies" $dependencies -}}
+	{{- $page.Store.Set "dependencies" $dependencies -}}
 {{ end }}

--- a/layouts/_partials/utilities/GetBaseURL.html
+++ b/layouts/_partials/utilities/GetBaseURL.html
@@ -1,0 +1,18 @@
+{{/*
+    Returns the site's base URL path for the current language, e.g. "/" for a site served from
+    the domain root and "/docs/" for a site served from a subdirectory. The language prefix is
+    stripped from the home page's relative permalink: on a multilingual site (or a site with
+    defaultContentLanguageInSubdir enabled) the home permalink carries the language as a
+    trailing path segment ("/fr/", "/docs/fr/"), which trims to the shared base path; when the
+    language is served from the root the trim is a no-op.
+
+    The partial depends exclusively on site state (site.Language.Lang and
+    site.Home.RelPermalink) and takes no page input, so its result is identical for every page
+    within a language. Invoke it as `partialCached "utilities/GetBaseURL.html" site` to amortize
+    the cost across the build; partialCached caches per language automatically.
+
+    Arguments: none (the context argument serves as the cache key only; pass `site`).
+*/}}
+
+{{- $lang := site.Language.Lang -}}
+{{- return strings.TrimSuffix (printf "%s/" $lang) site.Home.RelPermalink -}}


### PR DESCRIPTION
## Render-once program — slice D1

Part of the Hinode render-once implementation program (design:
gethinode.com `docs/superpowers/specs/2026-07-15-content-render-once-design.md`, §4.4/§4.5/§6-D1, decision §8-Q6).

### Changes
- **AddModule.html** — the `page` argument is now the primary context; omitting it is deprecated
  (falls back to the global `page` for one release). The `dependencies` accumulator is dual-written
  to both `.Scratch` (current consumers) and `.Store` (successor — survives content-render timing).
  The deprecation LogWarn is gated behind `site.Params.debugging.showDeprecations` while mod-blocks
  `list.hugo.html` still omits the argument (fixed in slice D4); it keeps
  `warnid "warn-deprecated-arguments"` for dedup.
- **GetBaseURL.html** (new) — pure, page-independent per-language base URL
  (`strings.TrimSuffix (printf "%s/" site.Language.Lang) site.Home.RelPermalink`), designed for
  `partialCached … site`. No callers yet; hinode adopts it in slice D5.

### Gate evidence (byte-diff, hinode exampleSite @ 50b5612b, hugo v0.164.0)
- Stock ×2 + candidate ×2 (via `HUGO_MODULE_REPLACEMENTS`): all builds 98/26/24 pages, zero ERROR,
  WARN sets byte-identical.
- `diff -rq` run-vs-run and candidate-vs-stock: only the 3 known allowlisted RSS files differ
  (pre-existing `.Content` race, deleted in slice D8).
- Independently re-verified by the program driver.
- mod-utils golden test suite green.

Releases as **v6.6.0** (also absorbs the unreleased automated dep-bump `fix:` commits on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)