### PR TITLE
fix: attribute diagnostic warnings to the intrinsic page (render-once D7)

### DIFF
--- a/layouts/_partials/utilities/GetDescription.html
+++ b/layouts/_partials/utilities/GetDescription.html
@@ -5,7 +5,7 @@
         "partial" "utilities/description.html" 
         "msg" "Invalid arguments"
         "details" $args.errmsg
-        "file" page.File
+        "file" (or $args.page page).File
     )}}
 {{ end }}
 

--- a/layouts/_partials/utilities/GetPage.html
+++ b/layouts/_partials/utilities/GetPage.html
@@ -1,8 +1,12 @@
 {{- $ref := "" -}}
 {{- $anchor := "" -}}
 
+{{/* Attribute errors to the caller-provided page when it is file-backed; the global page
+    context identifies the render that triggered this call, which may be a foreign page
+    (e.g. an output format touching another page's .Content). */}}
 {{ $origin := "" }}
-{{ with page.File }}{{ $origin = .Path }}{{ else }}{{ $origin = page.File }}{{ end }}
+{{ with page.File }}{{ $origin = .Path }}{{ end }}
+{{ with .page }}{{ with .File }}{{ $origin = .Path }}{{ end }}{{ end }}
 
 {{ $url := .url }}
 {{ if not $url }}

--- a/layouts/_partials/utilities/bundlev2.html
+++ b/layouts/_partials/utilities/bundlev2.html
@@ -12,7 +12,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($args.errmsg | append $args.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     ) -}}
 {{- end -}}
 


### PR DESCRIPTION
## Render-once program — slice D7

4 sites switched to the intrinsic page (GetDescription, bundlev2, GetPage origin); 8 left global with rationale (no page in scope; no new args added per design).

Part of the Hinode render-once implementation program (design: gethinode.com `docs/superpowers/specs/2026-07-15-content-render-once-design.md` §2.3/§4.5/§6-D7, Appendix C). Diagnostics-only: replaces global-`page` warning attribution with the intrinsic page where one is in scope; no output bytes change.

**Gate:** exampleSite with all four D7 module branches replaced simultaneously — 0 ERROR, 98/26/24 pages, WARN set identical; candidate vs unpatched-main control: byte-neutral (only the 3 allowlisted RSS files). Independently re-verified by the program driver. Module test suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)