### PR TITLE
fix: deprecate the purgeHTMLComments parameter of ProcessContent (render-once D8)

### DIFF
--- a/layouts/_partials/utilities/ProcessContent.html
+++ b/layouts/_partials/utilities/ProcessContent.html
@@ -1,12 +1,31 @@
-<!-- 
-    Purges any HTML comments from raw content, if applicable. The partial supports the following arguments:
+<!--
+    Renders raw Markdown input as a content fragment, optionally purging HTML comments first.
+    Since the render-once release, Hinode serves page bodies from Hugo's cached .Content; this
+    partial remains the render path for fragments only. The partial supports the following
+    arguments:
     "page"          Required page context, used to render shortcodes properly.
-    "raw"           Raw page content, e.g. .Page.RawContent.
+    "raw"           Raw fragment content, e.g. a trimmed .RawContent or a shortcode's .Inner.
+
+    The site parameter `debugging.purgeHTMLComments` is deprecated: page bodies no longer flow
+    through this partial, so the parameter cannot keep its input-side meaning — it now affects
+    fragments only. The purge branch keeps working for fragments in this release and will be
+    removed in mod-utils v7. Use Hugo's `ignoreLogs = ['warning-goldmark-raw-html']` site
+    setting to suppress the Goldmark raw-HTML warning instead. The deprecation warning is
+    gated behind the site parameter `debugging.showDeprecations` while in-org sites still set
+    the parameter, so that site authors are not warned about configuration they inherited.
 -->
 
 {{ $page := .page -}}
 {{ $raw := .raw -}}
 {{- if site.Params.debugging.purgeHTMLComments -}}
+    {{- if site.Params.debugging.showDeprecations -}}
+        {{- partial "utilities/LogWarn.html" (dict
+            "partial" "utilities/ProcessContent.html"
+            "warnid"  "warn-deprecated-purge-html-comments"
+            "msg"     "Parameter 'debugging.purgeHTMLComments' is deprecated and will be removed in v7, use ignoreLogs = ['warning-goldmark-raw-html'] instead"
+            "file"    $page.File
+        ) -}}
+    {{- end -}}
     {{- $raw = replaceRE "<!--(.|\n)*?-->" "" $raw -}}
 {{- end -}}
 {{ $content := emojify $raw | $page.RenderString }}


### PR DESCRIPTION
## Render-once program — slice D8, mod-utils half

Part of the Hinode render-once implementation program (design §5, decision §8-Q3).

`purgeHTMLComments` cannot keep its input-side meaning once page bodies serve from `.Content`
(no pre-render hook exists). This release: a deprecation LogWarn (`warnidf`, gated behind
`debugging.showDeprecations` per the D1 precedent — hinode's exampleSite still sets the param
until the flip PR lands) while the purge behavior keeps working for fragment renders. Removal
slated for mod-utils v7 (documented in the partial header).

**Gate:** byte- and WARN-neutral vs stock (exampleSite, replacement build); positive test: warn
fires with correct attribution when `showDeprecations` is enabled. Golden suite green.
Independently reviewed by the program driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)