### PR TITLE
feat: add bundlev3, a js.Build-based script bundling engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,47 @@ behavior changes in ways that can affect rendered output and build logs.
    - New warnings (see the rollout section above) may appear in your build logs; they are
      non-blocking in v6 and indicate call sites to clean up before v7.
 
+## Script bundling
+
+The module provides two script-bundling engines that share the same collection semantics
+(match pattern or module expansion over `basepath`, name-sorted processing, a `.js`/`.mjs`
+split returned as `{bundle, module}`, and per-file Go-template processing controlled by
+`skip-template`/`enable-template`):
+
+- **`utilities/bundlev2.html`** — the concatenation lane. Matched files are (optionally)
+  executed as Go templates and concatenated with `resources.Concat`. This engine remains
+  available and unchanged.
+- **`utilities/bundlev3.html`** — the js.Build (esbuild) lane. The partial generates a
+  virtual entry file and compiles it with `js.Build`. The `bundle` result is an
+  iife-format build of the matched `.js` files; the `module` result is an esm-format
+  build of the matched `.mjs` files (an empty inline resource when nothing matches).
+
+`bundlev3` accepts every `bundlev2` argument (`page`, `match`, `filename`, `modules`,
+`all`, `basepath`, `skip-template`, `enable-template`, `debugging`) plus:
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `globals` | dict | Map of asset paths to window property names, e.g. `js/modules/bootstrap/bootstrap.bundle.js: bootstrap`. UMD distributions do not register their window global when bundled by esbuild; each listed file is imported as a namespace ahead of all other imports and assigned to the given window property. |
+| `externals` | []string | Import paths marked as external in esbuild, e.g. `worker_threads` for distributions with a Node-guarded `require`. |
+| `params` | dict | Dictionary passed to `js.Build`; bundled files can `import ... from '@params'`. |
+| `target` | string | Language target passed to `js.Build` (default `es2022`). |
+| `sourcemap` | bool | Emit a linked source map; intended for non-production environments. |
+
+Ordering semantics: files processed as a Go template cannot be imported (resources
+produced by `resources.ExecuteAsTemplate` are not part of the assets filesystem), so
+their executed content is inlined into the entry text; other files are imported from
+the assets filesystem. Since esbuild hoists imports, the effective execution order is:
+the `globals` modules (map-key sort order), the plain imported modules (name-sorted),
+then the entry body — the window-global assignments followed by the inlined file
+contents (name-sorted). A file that reads a configured window global at load time must
+be part of the inlined (templated) group.
+
+Minification is applied by esbuild in production environments (callers should not minify
+again); callers remain responsible for fingerprinting. `js.Build` writes an editor
+helper file `jsconfig.json` to the project's assets folder as a side effect. Use
+`bundlev2` when plain concatenation or template-only processing is required; use
+`bundlev3` for tree-shaken, scoped bundles with import resolution.
+
 ## Contributing
 
 This module uses [semantic-release][semantic-release] to automate the release of new versions. The package uses `husky` and `commitlint` to ensure commit messages adhere to the [Conventional Commits][conventionalcommits] specification. You can run `npx git-cz` from the terminal to help prepare the commit message.

--- a/data/structures/bundlev3.yml
+++ b/data/structures/bundlev3.yml
@@ -1,0 +1,89 @@
+comment: >-
+  Bundles a selection of script files into a single file using js.Build
+  (esbuild). Mirrors the collection semantics of `bundle` (bundlev2) and adds
+  esbuild-specific arguments.
+group: partial
+arguments:
+  page:
+  match:
+    type: string
+    optional: true
+    comment: Filename or glob pattern of the source file(s) to bundle.
+  filename:
+    type: string
+    optional: false
+    comment: Filename of the target bundle.
+  modules:
+    type: "[]string"
+    optional: true
+    comment: >-
+      Names of the modules to bundle. When `all` is set, a glob pattern
+      consisting of the `basepath`, module name, and default extension is added.
+      Else, a single file is matched.
+  all:
+    type: bool
+    optional: true
+    comment: >-
+      Flag to indicate the module should include a glob pattern to match all
+      nested files.
+  skip-template:
+    type: bool
+    optional: true
+    comment: >-
+      Flag to indicate the matched files should not be processed using
+      `resources.ExecuteAsTemplate`. Set this to true when encountering
+      processing issues due to syntax conflicts. Files processed as a template
+      are inlined into the generated entry file; other files are imported from
+      the assets filesystem instead.
+  enable-template:
+    type: string
+    optional: true
+    comment: >-
+      Glob pattern to define which source files should be processed as Hugo
+      template. The pattern takes precedence over `skip-template`.
+  basepath:
+    type: string
+    optional: true
+    comment: >-
+      Base path to use when defining a module glob pattern. See `modules` for
+      more details.
+  globals:
+    type: dict
+    optional: true
+    comment: >-
+      Map of matched asset paths to window property names, e.g.
+      `js/modules/bootstrap/bootstrap.bundle.js: bootstrap`. UMD distributions
+      do not register their window global when bundled by esbuild; each file
+      listed here is imported as a namespace ahead of all other imports and
+      assigned to the given window property in the entry body. Files listed
+      here are excluded from template processing and inlining.
+  externals:
+    type: "[]string"
+    optional: true
+    comment: >-
+      Import paths to mark as external in esbuild (passed through to js.Build),
+      e.g. `worker_threads` for distributions with a Node-guarded require.
+  params:
+    type: dict
+    optional: true
+    comment: >-
+      Dictionary passed to js.Build; bundled files can import these values
+      from `@params`.
+  target:
+    type: string
+    optional: true
+    default: es2022
+    comment: Language target passed to js.Build.
+  sourcemap:
+    type: bool
+    optional: true
+    comment: >-
+      Flag to generate a linked source map for the bundle. Intended for
+      non-production environments; minification is applied automatically in
+      production environments instead.
+  debugging:
+    type: bool
+    optional: true
+    comment: >-
+      Flag to display how the source files are processed (exposed as global,
+      imported, or inlined).

--- a/layouts/_partials/utilities/bundlev3.html
+++ b/layouts/_partials/utilities/bundlev3.html
@@ -1,0 +1,259 @@
+{{/*
+    Copyright © 2022 - 2026 The Hinode Team / Mark Dumay. All rights reserved.
+    Use of this source code is governed by The MIT License (MIT) that can be found in the LICENSE file.
+    Visit gethinode.com/license for more details.
+*/}}
+
+{{/*
+    Bundles a selection of script files into a single output file using js.Build (esbuild).
+    The partial mirrors the interface and collection semantics of bundlev2.html (which
+    remains available as the concatenation lane) and generates a virtual entry file that
+    is compiled by js.Build.
+
+    Matched files are classified into three groups:
+     1. Globals - files listed in the `globals` argument (asset path -> window property
+        name). UMD distributions do not register their window global when bundled by
+        esbuild (the CommonJS interop captures the exports instead). Each configured file
+        is imported as a namespace (`import * as __globalN from '<path>'`) and assigned to
+        the requested window property in the entry body. These import statements are
+        emitted first, in map-key sort order. Files listed in `globals` are excluded from
+        template processing and from the plain import list.
+     2. Imports - files not processed as a Go template (see `skip-template` and
+        `enable-template`). Emitted as side-effect imports (`import '<path>'`) in
+        name-sorted order, resolved against Hugo's merged assets filesystem.
+     3. Inlined files - files processed with resources.ExecuteAsTemplate. Resources
+        produced by ExecuteAsTemplate are NOT part of the assets filesystem and CANNOT be
+        imported by the generated entry. Their executed content is therefore inlined into
+        the entry text itself, in name-sorted order, each preceded by an
+        `// inlined: <name>` marker.
+
+    Execution order of the resulting bundle: esbuild hoists all import statements, so all
+    imported modules execute BEFORE any inline entry code. The effective order is:
+     1. the modules of the configured globals (map-key sort order);
+     2. the plain imported modules (name-sorted order);
+     3. the entry body: the window-property assignments for the configured globals,
+        followed by the inlined file contents (name-sorted order).
+    Note that the window-property assignments are entry-body statements: they run after
+    ALL imported modules have executed. A file that reads a configured window global at
+    load time must therefore be part of the inlined (templated) group.
+
+    Matched `.js` files are compiled to an iife-format bundle ("bundle"); matched `.mjs`
+    files are compiled through their own generated entry to an esm-format bundle
+    ("module"). Either value is an empty inline resource when there is nothing to bundle
+    (no imports and no inline code beyond comments), allowing callers to skip empty
+    bundles. Minification is applied by esbuild in production environments; callers
+    remain responsible for fingerprinting. Side effect: js.Build writes an editor helper
+    file `jsconfig.json` to the assets folder of the project.
+*/}}
+
+{{/* Define inline partials */}}
+{{- define "_partials/inline/bundlev3/relpath.html" -}}
+    {{/* Import path from the generated entry (in folder .dir) to asset .name */}}
+    {{- $result := "" -}}
+    {{- if or (eq .dir ".") (eq .dir "") -}}
+        {{- $result = printf "./%s" .name -}}
+    {{- else if hasPrefix .name (printf "%s/" .dir) -}}
+        {{- $result = printf "./%s" (strings.TrimPrefix (printf "%s/" .dir) .name) -}}
+    {{- else -}}
+        {{- $result = printf "%s%s" (strings.Repeat (len (split .dir "/")) "../") .name -}}
+    {{- end -}}
+    {{- return $result -}}
+{{- end -}}
+
+{{- define "_partials/inline/bundlev3/build.html" -}}
+    {{/* Assemble the entry text for a group of files and compile it with js.Build */}}
+    {{- $args := .args -}}
+    {{- $filename := .filename -}}
+    {{- $globals := .globals -}}
+    {{- $imports := .imports -}}
+    {{- $inline := .inline -}}
+
+    {{- $entryDir := path.Dir $filename -}}
+    {{- $lines := slice -}}
+    {{- $assignments := slice -}}
+
+    {{/* Namespace imports and window assignments for the configured globals, in map-key
+        sort order (Go template map iteration is key-sorted) */}}
+    {{- range $file, $prop := $globals -}}
+        {{- $id := printf "__global%d" (len $assignments) -}}
+        {{- $path := partial "inline/bundlev3/relpath.html" (dict "dir" $entryDir "name" $file) -}}
+        {{- $lines = $lines | append (printf "import * as %s from '%s';" $id $path) -}}
+        {{- $assignments = $assignments | append (printf "window.%s = %s && %s.default ? %s.default : %s;" $prop $id $id $id $id) -}}
+    {{- end -}}
+
+    {{/* Side-effect imports of the non-templated files, in name-sorted order */}}
+    {{- range $imports -}}
+        {{- $path := partial "inline/bundlev3/relpath.html" (dict "dir" $entryDir "name" .) -}}
+        {{- $lines = $lines | append (printf "import '%s';" $path) -}}
+    {{- end -}}
+
+    {{/* Entry body: window assignments first, then the inlined templated content in
+        name-sorted order. Each block is terminated with an explicit `;` statement to
+        avoid unintended expression continuation across files (e.g. a file ending in
+        `})()` followed by a file starting with `(function`) */}}
+    {{- $lines = $lines | append $assignments -}}
+    {{- range $inline -}}
+        {{- $lines = $lines | append (printf "// inlined: %s" .name) (string .content) ";" -}}
+    {{- end -}}
+
+    {{/* Empty-bundle guard: return an empty inline resource when the entry contains no
+        imports and no inline code beyond comments, so callers can skip the bundle */}}
+    {{- $inlineCode := "" -}}
+    {{- range $inline -}}{{ $inlineCode = printf "%s\n%s" $inlineCode .content }}{{- end -}}
+    {{- $inlineCode = $inlineCode | replaceRE `(?m)//[^\n]*` "" | replaceRE `(?s)/\*.*?\*/` "" | strings.TrimSpace -}}
+
+    {{- $bundle := "" -}}
+    {{- if or (gt (len $globals) 0) (gt (len $imports) 0) (gt (len $inlineCode) 0) -}}
+        {{- $opts := dict
+            "targetPath" $filename
+            "format"     .format
+            "target"     $args.target
+            "minify"     hugo.IsProduction
+        -}}
+        {{- with $args.externals }}{{ $opts = merge $opts (dict "externals" .) }}{{ end -}}
+        {{- with $args.params }}{{ $opts = merge $opts (dict "params" .) }}{{ end -}}
+        {{- if $args.sourcemap }}{{ $opts = merge $opts (dict "sourceMap" "linked") }}{{ end -}}
+
+        {{- $entryName := path.Join $entryDir (printf "__entry-%s-%s" $args.page.Language.Lang (path.Base $filename)) -}}
+        {{- $bundle = resources.FromString $entryName (delimit $lines "\n") | js.Build $opts -}}
+    {{- else -}}
+        {{- $bundle = resources.FromString $filename "" -}}
+    {{- end -}}
+    {{- return $bundle -}}
+{{- end -}}
+
+{{/* Initialize arguments */}}
+{{- $args := partial "utilities/InitArgs.html" (dict "structure" "bundlev3" "args" .) -}}
+{{- if or $args.err $args.warnmsg -}}
+    {{- partial (cond $args.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict
+        "partial" "utilities/bundlev3.html"
+        "warnid"  "warn-invalid-arguments"
+        "msg"     "Invalid arguments"
+        "details" ($args.errmsg | append $args.warnmsg)
+        "file"    (or $args.page page).File
+    ) -}}
+{{- end -}}
+
+{{/* Initialize local arguments */}}
+{{- $match := $args.match -}}
+{{- $basepath := strings.TrimSuffix "/" $args.basepath -}}
+{{- $ext := trim (path.Ext (trim $match "{}")) "." | default "*js" -}}
+{{- if not $ext -}}
+    {{- errorf "partial [utilities/bundlev3.html] - Cannot derive file extension of match pattern: %s" $match -}}
+{{- end -}}
+{{/* Normalize the globals keys: resource names carry a leading slash on newer Hugo
+    versions, while the argument is documented without one — accept both */}}
+{{- $globals := dict -}}
+{{- range $key, $val := $args.globals | default dict -}}
+    {{- $globals = merge $globals (dict (strings.TrimPrefix "/" $key) $val) -}}
+{{- end -}}
+
+{{/* Initialize return variables */}}
+{{ $bundle := "" }}
+{{ $modBundle := "" }}
+
+{{/* Main code */}}
+{{- if not $args.err -}}
+    {{- if $args.modules -}}
+        {{- $match = trim $match "{}" -}}
+        {{- $matches := slice $match -}}
+        {{- range $index, $mod := $args.modules -}}
+            {{- if $args.all }}
+                {{- $matches = $matches | append (printf "%s/%s/**.%s" $basepath $mod $ext) -}}
+            {{- else -}}
+                {{- $matches = $matches | append (printf "%s/%s.%s" $basepath $mod $ext) -}}
+            {{- end -}}
+        {{- end -}}
+        {{- $match = printf "{%s}" (trim (delimit $matches ",") ",") }}
+    {{- end -}}
+
+    {{ $matches := resources.Match $match }}
+    {{ $templates := cond $args.enableTemplate (resources.Match $args.enableTemplate) dict }}
+    {{ $files := slice }}
+    {{ range $index, $file := $matches }}
+        {{ $add := (dict "name" (strings.TrimSuffix (path.Ext $file.Name) $file.Name) "resource" $file ) }}
+        {{ $files = $files | append $add }}
+    {{ end }}
+
+    {{/* Classify the matched files into globals, plain imports, and inlined templated
+        content, split between the iife (.js) and esm (.mjs) bundles */}}
+    {{ $jsGlobals := dict }}
+    {{ $jsImports := slice }}
+    {{ $jsInline := slice }}
+    {{ $modGlobals := dict }}
+    {{ $modImports := slice }}
+    {{ $modInline := slice }}
+    {{ $files = sort $files "name" }}
+    {{- range $index, $file := $files -}}
+        {{/* Normalize the resource name: newer Hugo versions return names with a
+            leading slash, which would break the relative import paths */}}
+        {{ $name := strings.TrimPrefix "/" $file.resource.Name }}
+        {{ $isMod := hasSuffix (lower $name) ".mjs" }}
+        {{ $winProp := index $globals $name }}
+
+        {{ if $winProp }}
+            {{ if $isMod }}
+                {{ $modGlobals = merge $modGlobals (dict $name $winProp) }}
+            {{ else }}
+                {{ $jsGlobals = merge $jsGlobals (dict $name $winProp) }}
+            {{ end }}
+        {{ else }}
+            {{ $process := false }}
+            {{ range $templates }}
+                {{ if eq (strings.TrimPrefix "/" .Name) $name }}
+                    {{ $process = true }}
+                    {{ break }}
+                {{ end }}
+            {{ end }}
+
+            {{ if or $process (not $args.skipTemplate) }}
+                {{- $res := resources.ExecuteAsTemplate (path.Join $args.page.Language.Lang $name) $args.page $file.resource -}}
+                {{ $add := dict "name" $name "content" $res.Content }}
+                {{ if $isMod }}{{ $modInline = $modInline | append $add }}{{ else }}{{ $jsInline = $jsInline | append $add }}{{ end }}
+            {{ else }}
+                {{ if $isMod }}{{ $modImports = $modImports | append $name }}{{ else }}{{ $jsImports = $jsImports | append $name }}{{ end }}
+            {{ end }}
+        {{ end }}
+    {{- end -}}
+
+    {{/* Warn about configured globals that did not match any bundled file */}}
+    {{- range $file, $prop := $globals -}}
+        {{- if not (or (isset $jsGlobals $file) (isset $modGlobals $file)) -}}
+            {{ warnf "partial [utilities/bundlev3.html] - Global '%s' (window.%s) does not match any bundled file of '%s'" $file $prop $args.filename }}
+        {{- end -}}
+    {{- end -}}
+
+    {{- if $args.debugging -}}
+        {{ warnf "Processing pattern for '%s': %s" $args.filename $match }}
+        {{- range $file, $prop := merge $jsGlobals $modGlobals -}}
+            {{- warnf " - Exposing global: %s -> window.%s" $file $prop }}
+        {{- end -}}
+        {{- range append $jsImports $modImports -}}
+            {{- warnf " - Importing file: %s" . }}
+        {{- end -}}
+        {{- range append $jsInline $modInline -}}
+            {{- warnf " - Inlining file: %s" .name }}
+        {{- end -}}
+    {{- end -}}
+
+    {{ $bundle = partial "inline/bundlev3/build.html" (dict
+        "args"     $args
+        "filename" $args.filename
+        "format"   "iife"
+        "globals"  $jsGlobals
+        "imports"  $jsImports
+        "inline"   $jsInline
+    ) }}
+
+    {{ $modFilename := printf "%s.mjs" (strings.TrimSuffix (path.Ext $args.filename) $args.filename) }}
+    {{ $modBundle = partial "inline/bundlev3/build.html" (dict
+        "args"     $args
+        "filename" $modFilename
+        "format"   "esm"
+        "globals"  $modGlobals
+        "imports"  $modImports
+        "inline"   $modInline
+    ) }}
+{{- end -}}
+
+{{- return (dict "bundle" $bundle "module" $modBundle) -}}


### PR DESCRIPTION
## Summary

New `utilities/bundlev3.html` partial: a js.Build (esbuild) bundling engine beside the untouched `bundlev2.html` concat lane, plus the `bundlev3` args schema and README docs.

- Generated virtual entry per bundle (per-language): configured **globals** get `import * as` + `window.X` assignment (UMD dists don't self-register under esbuild's CJS interop); non-templated files become side-effect imports; templated files are inlined into the entry (ExecuteAsTemplate output cannot be graph-imported — imports hoist and run first; execution order documented in the partial header)
- `target` (default es2022), `externals`, `params` (importable as `@params`), `sourcemap` (emits `sourceMap "linked"`), esbuild `minify` in production (callers keep fingerprinting)
- ASI guard between inlined blocks; leading-slash resource-name normalization (Hugo ≥ 0.155); warnf on unmatched globals; empty-bundle guard compatible with hinode's comments-only check

## Evidence (js-pipeline program, Wave 0 + J3 gates)

- Inert on an unmodified hinode v3.6.2 exampleSite (281 JS artifacts byte-identical)
- Scratch flip of hinode's critical+core lanes: 0 ERROR, page counts 98/26/24, runtime smoke green (bootstrap data-api, theme toggle, FlexSearch), SRI intact
- core.bundle.en 148,640 B raw / 47,830 B gzip vs 200,330/54,245 stock (−25.8% raw)
- Validated on Hugo 0.164.0 AND 0.147.6 (project floor 0.146)
- Consumed by hinode PR (js/j4-esm-adoption, opened separately and held)

🤖 Generated with [Claude Code](https://claude.com/claude-code)