### PR TITLE
feat: accept script globals as an array of {path, name} tables

### DIFF
--- a/layouts/_partials/utilities/bundlev3.html
+++ b/layouts/_partials/utilities/bundlev3.html
@@ -11,13 +11,14 @@
     is compiled by js.Build.
 
     Matched files are classified into three groups:
-     1. Globals - files listed in the `globals` argument (asset path -> window property
-        name). UMD distributions do not register their window global when bundled by
-        esbuild (the CommonJS interop captures the exports instead). Each configured file
-        is imported as a namespace (`import * as __globalN from '<path>'`) and assigned to
-        the requested window property in the entry body. These import statements are
-        emitted first, in map-key sort order. Files listed in `globals` are excluded from
-        template processing and from the plain import list.
+     1. Globals - files listed in the `globals` argument, an array of tables each with a
+        `path` (asset path) and `name` (window property name). UMD distributions do not
+        register their window global when bundled by esbuild (the CommonJS interop
+        captures the exports instead). Each configured file is imported as a namespace
+        (`import * as __globalN from '<path>'`) and assigned to the requested window
+        property in the entry body. These import statements are emitted first, in
+        map-key sort order (internally keyed by path). Files listed in `globals` are
+        excluded from template processing and from the plain import list.
      2. Imports - files not processed as a Go template (see `skip-template` and
         `enable-template`). Emitted as side-effect imports (`import '<path>'`) in
         name-sorted order, resolved against Hugo's merged assets filesystem.
@@ -141,11 +142,20 @@
 {{- if not $ext -}}
     {{- errorf "partial [utilities/bundlev3.html] - Cannot derive file extension of match pattern: %s" $match -}}
 {{- end -}}
-{{/* Normalize the globals keys: resource names carry a leading slash on newer Hugo
-    versions, while the argument is documented without one — accept both */}}
+{{/* Build the internal globals map (asset path -> window property). The argument is
+    the array-of-tables form [{path, name}], but a legacy path-keyed map is still
+    accepted so a newer mod-utils keeps working under an older reader that passes a
+    map. Resource names carry a leading slash on newer Hugo versions, while the
+    argument is documented without one — accept both. */}}
 {{- $globals := dict -}}
-{{- range $key, $val := $args.globals | default dict -}}
-    {{- $globals = merge $globals (dict (strings.TrimPrefix "/" $key) $val) -}}
+{{- if reflect.IsMap $args.globals -}}
+    {{- range $key, $val := $args.globals -}}
+        {{- $globals = merge $globals (dict (strings.TrimPrefix "/" $key) $val) -}}
+    {{- end -}}
+{{- else -}}
+    {{- range $args.globals | default slice -}}
+        {{- $globals = merge $globals (dict (strings.TrimPrefix "/" .path) .name) -}}
+    {{- end -}}
 {{- end -}}
 
 {{/* Initialize return variables */}}


### PR DESCRIPTION
## Summary

The script-globals mechanism keyed the `globals` argument by asset **path**. Hugo lowercases TOML config keys, so a map keyed by path silently breaks for **capitalized** bundle filenames (e.g. GSAP's `ScrollTrigger.js` → `scrolltrigger.js`, which no longer matches the case-sensitive mounted resource). Only all-lowercase bundle names (bootstrap, flexsearch) worked.

This changes `bundlev3.html` to accept `globals` as an **array-of-tables** `[{path, name}]`, so the path is carried as a **value** (case-preserved) rather than a key. The internal path→window-property map and all downstream handling are unchanged.

## Backward compatibility

A legacy path-keyed **map** is still accepted (via `reflect.IsMap`) and normalized to the same internal shape, so a newer mod-utils keeps working under an older reader that passes a map. No consumer breaks.

## Verification

- mod-utils exampleSite builds clean (dev).
- Proven end-to-end against a real GSAP consumer (infusal.io): with this + the matching hinode reader, a production build injects `window.gsap`, `window.ScrollTrigger`, and `window.SplitText` — all **case-correct** — and the live page runs all GSAP/ScrollTrigger animations with zero console errors. Map-format (bootstrap/FlexSearch) and array-format (gsap) globals coexist in the same build.

Part of a coordinated set: hinode reader (array + map), mod-gsap/mod-bootstrap/mod-flexsearch declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)