### PR TITLE
fix: preserve interior capitals in camel-key for camelCase-declared arguments

### DIFF
--- a/exampleSite/content/tests/camelcase.md
+++ b/exampleSite/content/tests/camelcase.md
@@ -1,0 +1,4 @@
+---
+title: camelcase
+outputs: ["json"]
+---

--- a/exampleSite/data/structures/test-camel.yml
+++ b/exampleSite/data/structures/test-camel.yml
@@ -1,0 +1,19 @@
+comment: >-
+  Test fixture for arguments DECLARED in camelCase (regression: camel-key used to lowercase
+  the whole first word, storing provided values under a key consumers never read).
+arguments:
+  overlayMode:
+    type: select
+    optional: true
+    default: dark
+    options:
+      values: [light, dark, none]
+  logo-align:
+    type: select
+    optional: true
+    default: start
+    options:
+      values: [start, center, end]
+  plainkey:
+    type: string
+    optional: true

--- a/exampleSite/data/tests/camelcase.yml
+++ b/exampleSite/data/tests/camelcase.yml
@@ -1,0 +1,21 @@
+cases:
+  # Regression: a value provided under a camelCase-DECLARED key must surface under that key
+  # (camelKey == declared key), not be silently replaced by the schema default.
+  - name: camel-declared-provided
+    structure: test-camel
+    args: {overlayMode: light}
+  - name: camel-declared-defaulted
+    structure: test-camel
+    args: {}
+  # Contrast: kebab-declared keys keep their existing camelization (logo-align -> logoAlign).
+  - name: kebab-declared-provided
+    structure: test-camel
+    args: {logo-align: center}
+  # All-lowercase declared keys are unaffected.
+  - name: lowercase-declared-provided
+    structure: test-camel
+    args: {plainkey: value}
+  # The compiled schema exposes the camelKeys directly.
+  - name: schema-camel-keys
+    structure: test-camel
+    api: schema

--- a/layouts/_partials/utilities/ArgsSchema.html
+++ b/layouts/_partials/utilities/ArgsSchema.html
@@ -30,7 +30,11 @@
         {{ if gt $index 0 }}
             {{ $result = print $result (strings.FirstUpper $word) }}
         {{ else }}
-            {{ $result = strings.ToLower $word }}
+            {{/* lowercase only the first rune: a key DECLARED in camelCase (e.g.
+                 `overlayMode`) must keep its interior capitals, otherwise provided
+                 values are stored under a camelKey (`overlaymode`) that consuming
+                 partials never read and silently fall back to defaults */}}
+            {{ $result = print (strings.ToLower (substr $word 0 1)) (substr $word 1) }}
         {{ end }}
     {{ end }}
     {{ return print $prefix $result }}

--- a/tests/golden/camelcase.json
+++ b/tests/golden/camelcase.json
@@ -1,0 +1,196 @@
+{
+  "camel-declared-defaulted": {
+    "args": {
+      "args": {
+        "logoAlign": "start",
+        "overlayMode": "dark"
+      },
+      "defaulted": [
+        "logo-align",
+        "overlayMode"
+      ],
+      "err": false,
+      "errmsg": [],
+      "warnmsg": []
+    },
+    "initargs": {
+      "default": [
+        "logo-align",
+        "overlayMode"
+      ],
+      "err": false,
+      "errmsg": [],
+      "logo-align": "start",
+      "logoAlign": "start",
+      "overlayMode": "dark",
+      "warnmsg": []
+    }
+  },
+  "camel-declared-provided": {
+    "args": {
+      "args": {
+        "logoAlign": "start",
+        "overlayMode": "light"
+      },
+      "defaulted": [
+        "logo-align"
+      ],
+      "err": false,
+      "errmsg": [],
+      "warnmsg": []
+    },
+    "initargs": {
+      "default": [
+        "logo-align"
+      ],
+      "err": false,
+      "errmsg": [],
+      "logo-align": "start",
+      "logoAlign": "start",
+      "overlayMode": "light",
+      "warnmsg": []
+    }
+  },
+  "kebab-declared-provided": {
+    "args": {
+      "args": {
+        "logoAlign": "center",
+        "overlayMode": "dark"
+      },
+      "defaulted": [
+        "overlayMode"
+      ],
+      "err": false,
+      "errmsg": [],
+      "warnmsg": []
+    },
+    "initargs": {
+      "default": [
+        "overlayMode"
+      ],
+      "err": false,
+      "errmsg": [],
+      "logo-align": "center",
+      "logoAlign": "center",
+      "overlayMode": "dark",
+      "warnmsg": []
+    }
+  },
+  "lowercase-declared-provided": {
+    "args": {
+      "args": {
+        "logoAlign": "start",
+        "overlayMode": "dark",
+        "plainkey": "value"
+      },
+      "defaulted": [
+        "logo-align",
+        "overlayMode"
+      ],
+      "err": false,
+      "errmsg": [],
+      "warnmsg": []
+    },
+    "initargs": {
+      "default": [
+        "logo-align",
+        "overlayMode"
+      ],
+      "err": false,
+      "errmsg": [],
+      "logo-align": "start",
+      "logoAlign": "start",
+      "overlayMode": "dark",
+      "plainkey": "value",
+      "warnmsg": []
+    }
+  },
+  "schema-camel-keys": {
+    "schema": {
+      "absent": {
+        "logo-align": {
+          "defaulted": [
+            "logo-align"
+          ],
+          "errmsg": [],
+          "newmsg": [],
+          "value": "start",
+          "warnmsg": []
+        },
+        "overlayMode": {
+          "defaulted": [
+            "overlayMode"
+          ],
+          "errmsg": [],
+          "newmsg": [],
+          "value": "dark",
+          "warnmsg": []
+        },
+        "plainkey": {
+          "defaulted": [],
+          "errmsg": [],
+          "newmsg": [],
+          "value": null,
+          "warnmsg": []
+        }
+      },
+      "err": false,
+      "errmsg": [],
+      "positions": {},
+      "schema": {
+        "logo-align": {
+          "accepts": [
+            "string"
+          ],
+          "camelKey": "logoAlign",
+          "default": "start",
+          "kind": "scalar",
+          "name": "logo-align",
+          "optional": true,
+          "options": {
+            "values": [
+              "start",
+              "center",
+              "end"
+            ]
+          },
+          "types": [
+            "select"
+          ]
+        },
+        "overlayMode": {
+          "accepts": [
+            "string"
+          ],
+          "camelKey": "overlayMode",
+          "default": "dark",
+          "kind": "scalar",
+          "name": "overlayMode",
+          "optional": true,
+          "options": {
+            "values": [
+              "light",
+              "dark",
+              "none"
+            ]
+          },
+          "types": [
+            "select"
+          ]
+        },
+        "plainkey": {
+          "accepts": [
+            "string"
+          ],
+          "camelKey": "plainkey",
+          "kind": "scalar",
+          "name": "plainkey",
+          "optional": true,
+          "types": [
+            "string"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`ArgsSchema.html`'s inline `camel-key` helper lowercases the **entire first word** of a declared argument name. A key declared in camelCase — e.g. `overlayMode` in hinode's `navbar.yml` — therefore compiles to the camelKey `overlaymode`. `Args.html`/`InitArgs.html` store provided values under that camelKey, but consuming partials read the declared camelCase name (`$args.overlayMode`), so **provided values are silently dropped and the schema default applies**.

Real-world effect found while upgrading a production site to the v3 module generation: `navigation.overlayMode = "light"` never reached the navbar partial, which fell back to `dark` and rendered white nav links over a light hero. No warning is emitted — the value validates fine and then vanishes.

Keys declared in kebab-case (`logo-align`) or snake_case are unaffected, which is why the demo sites never showed it.

## Fix

Lowercase only the **first rune** of the first word. Kebab/snake names camelize exactly as before (`logo-align` → `logoAlign`); camelCase-declared names keep their interior capitals (`overlayMode` → `overlayMode`).

Note: `utilities/camelize.html` has the same first-word-lowercasing logic; left untouched here to keep this PR scoped to the args engine, but it may deserve the same treatment.

## Tests

- New `camelcase` golden group: camel-declared provided + defaulted, kebab-declared, lowercase-declared, and the compiled schema camelKeys.
- `npm test`: golden check passed (14 groups); **all existing goldens byte-identical** — no behavior change for kebab/snake/lowercase keys.
- Verified on the affected site: with this fix the navbar renders `data-bs-theme="light"`, matching its pre-upgrade production output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)