### PR TITLE
fix: declare label and url attributes on the elements item type

### DIFF
--- a/data/structures/_types.yml
+++ b/data/structures/_types.yml
@@ -70,6 +70,8 @@ types:
       mode:
       content:
       link:
+      label:
+      url:
   links:
     - title:
       url:


### PR DESCRIPTION
## Problem

Components read `element.label` and `element.url` from `elements`-typed arguments — mod-blocks' `cards` component renders `.label` as the card's button label (`cards.hugo.html`), and theme components use `label`/`url` for element links — but the shared `elements` item type in `data/structures/_types.yml` does not declare either attribute.

The v6 validation engine validates list items against this type registry (inline item schemas in per-structure files are not consulted for typed arguments), so any content that legitimately uses these attributes logs `warn-invalid-arguments: unsupported attribute` on **every render**. On a production site upgraded to the v3 generation this produced ~200 warnings per build for content that renders correctly. These warnings are slated to become errors in a future major, so the gap would eventually break valid sites.

## Fix

Add `label:` and `url:` to the `elements` item type. Both already have global definitions in `_arguments.yml` (`label` via the `messages` type, `url` via `links`), so the members compile without further changes.

## Verification

- `npm test`: golden check passed (13 groups), no golden changes (the suite exercises the engine against the exampleSite fixture types, not the shipped registry).
- The identical change applied as a site shadow removes all `unsupported attribute 'label'/'url'` warnings while the cards/hero elements keep rendering identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)