### PR TITLE
fix: cast whole-number floats to int in argument validation

### DIFF
--- a/exampleSite/data/tests/casting.yml
+++ b/exampleSite/data/tests/casting.yml
@@ -51,3 +51,12 @@ cases:
     structure: test-cast
     args:
       items-list: [1, "two", true]
+  # Whole-number floats cast losslessly to int (JSON round-trips — e.g. frontmatter
+  # injected by CloudCannon's visual editor — deliver every number as float64).
+  - name: whole-float-to-int
+    structure: test-cast
+    args: {count: 42.0}
+  # Fractional floats still fail the int type check.
+  - name: fractional-float-to-int
+    structure: test-cast
+    args: {count: 42.5}

--- a/layouts/_partials/utilities/Args.html
+++ b/layouts/_partials/utilities/Args.html
@@ -133,6 +133,14 @@
                 {{ $value = float $value }}
                 {{ $kind = "float" }}
             {{ end }}
+        {{ else if and (eq $kind "float") (in $node.accepts "int") (not (in $node.accepts "float")) (eq (float (int $value)) (float $value)) }}
+            {{/* whole-number floats cast losslessly to int. Data that round-trips through
+                 JSON — notably page frontmatter injected by CloudCannon's visual editor
+                 (Bookshop live rendering) — arrives with every number as float64, so an
+                 int argument would otherwise reject values the YAML source declares as
+                 plain integers. Fractional values still fail the type check below. */}}
+            {{ $value = int $value }}
+            {{ $kind = "int" }}
         {{ else if and (in $node.accepts "string") (in (slice "bool" "int" "float") $kind) (not (in $node.accepts $kind)) }}
             {{ $value = string $value }}
             {{ $kind = "string" }}

--- a/tests/golden/casting.json
+++ b/tests/golden/casting.json
@@ -62,6 +62,27 @@
       ]
     }
   },
+  "fractional-float-to-int": {
+    "args": {
+      "args": {
+        "count": 42.5
+      },
+      "defaulted": [],
+      "err": true,
+      "errmsg": [
+        "[test-cast] argument 'count': expected type 'int', got 'float64' with value '42.5'"
+      ],
+      "warnmsg": []
+    },
+    "initargs": {
+      "default": [],
+      "err": true,
+      "errmsg": [
+        "[test-cast] argument 'count': expected type 'int', got 'float64' with value '42.5'"
+      ],
+      "warnmsg": []
+    }
+  },
   "generic-dict-as-map": {
     "args": {
       "args": {
@@ -216,6 +237,24 @@
     }
   },
   "string-to-int": {
+    "args": {
+      "args": {
+        "count": 42
+      },
+      "defaulted": [],
+      "err": false,
+      "errmsg": [],
+      "warnmsg": []
+    },
+    "initargs": {
+      "count": 42,
+      "default": [],
+      "err": false,
+      "errmsg": [],
+      "warnmsg": []
+    }
+  },
+  "whole-float-to-int": {
     "args": {
       "args": {
         "count": 42


### PR DESCRIPTION
## Problem

In CloudCannon's visual editor, Bookshop live rendering injects the edited page's frontmatter into the embedded Hugo engine after a JSON round-trip — and JSON has no integer type, so **every number arrives as float64**. The v6 validation engine then rejects int-typed arguments with hard errors:

```
ERROR partial [assets/stack.html] - Invalid arguments:
  [stack] argument 'cols': expected type 'int', got 'float64' with value '4'
```

Observed on a production site's visual editor after upgrading to the v3 generation: every component with an int argument (`cols`, `padding`, `width`, `limit`, `heading.size`, …) fails to render in live preview with "Build failed: logged N error(s)", while CLI builds of the identical content pass — YAML parses those values as real ints, so the mismatch only appears in the live-editing path.

## Fix

Extend the casting block in `Args.html` (which already casts `"42"` → int and scalars → string): a float value with **no fractional part** whose argument accepts `int` but not `float` is cast losslessly to int. Fractional values (`42.5`) still fail the type check as before. Float-typed arguments are unaffected (they already accept int input, and float stays float).

## Tests

- New golden cases in the `casting` group: `whole-float-to-int` (42.0 → 42, no error) and `fractional-float-to-int` (42.5 → type error preserved).
- `npm test`: golden check passed (14 groups); all existing goldens byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)