### PR TITLE
fix: declare the cue and tab attributes on the links item type

### DIFF
--- a/data/structures/_types.yml
+++ b/data/structures/_types.yml
@@ -78,6 +78,10 @@ types:
       download:
       icon:
       force:
+      # no inherited default of its own: cue is declared optional without a
+      # default in _arguments.yml, so an absent value stays absent and the
+      # consuming partial applies main.externalLinks.cue
+      cue:
       # no inherited defaults: downstream partials layer their own (download.yml
       # sets outline/order; section context supplies order) as in v5
       order: { default: }

--- a/data/structures/_types.yml
+++ b/data/structures/_types.yml
@@ -78,10 +78,11 @@ types:
       download:
       icon:
       force:
-      # no inherited default of its own: cue is declared optional without a
-      # default in _arguments.yml, so an absent value stays absent and the
-      # consuming partial applies main.externalLinks.cue
+      # no inherited defaults of their own: cue and tab are declared optional
+      # without a default in _arguments.yml, so an absent value stays absent and
+      # the consuming partial applies main.externalLinks.cue / .tab
       cue:
+      tab:
       # no inherited defaults: downstream partials layer their own (download.yml
       # sets outline/order; section context supplies order) as in v5
       order: { default: }


### PR DESCRIPTION
Both `assets/link.html` and `assets/button.html` accept `cue` and `tab` — the per-element overrides for `main.externalLinks.cue` / `.tab` — but the shared `links` item type declares neither. Content that legitimately sets either on an entry of a links list therefore logs `warn-invalid-arguments` (`unsupported attribute`) on every render, through each partial in the chain (`hero`, `section-title`, `links`).

Both already have global definitions in `_arguments.yml` (`bool`, `optional`, no default), so the members compile without further changes and an absent value stays absent, leaving the consuming partial free to apply the site setting.

Same shape as #357, which declared `label` and `url` on the `elements` type.

## Verification

- `pnpm test` — golden check passes (14 groups).
- Applied against a production multilingual site on hinode v3.11.5 / mod-utils v6.8.3: six `unsupported attribute 'cue'` warnings per build drop to zero, with no other change to the build output.

## Note

This silences the validation warning. Making the attributes actually take effect needs the companion fix in hinode — gethinode/hinode#2092 — which forwards them through `assets/links.html` and stops `| default` from swallowing an explicit `false`. The two are independent and safe to merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
