### PR TITLE
fix(arguments): correct the cover argument description

### DIFF
--- a/data/structures/_arguments.yml
+++ b/data/structures/_arguments.yml
@@ -431,7 +431,11 @@ arguments:
     type: bool
     default: false
     optional: true
-    comment: Flag indicating if the element should be rendered fullscreen.
+    comment: >-
+      Flag indicating if the element should be rendered as a cover section,
+      filling most of the viewport height. Defaults to 88vh rather than the
+      full 100vh, so the next section peeks above the fold; see the site
+      settings `main.sectionHeight` and `main.maxSectionHeight`.
   cta:
     type: cta
     optional: true


### PR DESCRIPTION
Part of the fix for gethinode/hinode#2107.

## Problem

`data/structures/_arguments.yml` described the shared `cover` argument as:

> Flag indicating if the element should be rendered fullscreen.

This string is rendered verbatim into the generated argument tables for every block that accepts `cover` — hero, about, featured, cards, panels, cta, faq, and a dozen more. A cover section is 88vh, capped at 1024px on large viewports, so the description promised a full viewport the theme never delivers. It was the third of three places making that claim, alongside the hero docs and the block docs prose.

## Change

Describe the real behavior, say why it falls short of 100vh, and name the two site settings that control it.

Typed `fix` rather than `docs` so it releases and downstream modules can pick it up.

Golden tests pass (14 groups).

## Related

- gethinode/hinode#2108 — adds `main.sectionHeight` / `main.maxSectionHeight`
- gethinode/mod-docs#134 — corrects the hero block docs
- gethinode/mod-blocks#190 — forwards the `cover` flag into the hero body partial

🤖 Generated with [Claude Code](https://claude.com/claude-code)