### PR TITLE
feat(arguments): add heading-level and heading-class

### DIFF
--- a/data/structures/_arguments.yml
+++ b/data/structures/_arguments.yml
@@ -648,6 +648,22 @@ arguments:
     optional: true
     comment: >-
       Heading of the content block, including a preheading and content element.
+  heading-class:
+    type: string
+    optional: true
+    comment: >-
+      Class attributes of the heading element, applied only when a heading level
+      renders one. Replaces the margin reset that otherwise keeps a title raised
+      by heading-level aligned with the div it succeeds. Pass an empty string to
+      leave the element on its own styling.
+  heading-level:
+    type: int
+    optional: true
+    comment: >-
+      Heading level of the title, from 1 (h1) to 6 (h6). Set 0 to render a div
+      instead of a heading. Content blocks receive a level from the page that
+      renders them, so the first titled block of a page without a page header
+      becomes its h1.
   heading-style:
     type: select
     optional: true


### PR DESCRIPTION
## What

Defines `heading-level` and `heading-class` once, so consuming structures and component blueprints can reference them by bare key.

## Why

hinode v3.19.0 introduced both arguments as full inline definitions in `data/structures/section-title.yml`, and gethinode/mod-blocks#193 repeats the same six-line block in twelve component sidecars plus `hero.yml` and `preview.yml`. `use-title` — the boolean `heading-level` replaces — has always been a single entry here, referenced by bare key everywhere. These belong in the same place.

`heading-class` also joins an established family of shared arguments: `bg-class`, `icon-class`, `section-class` and `figclass` are all defined here already.

## Deliberately no default

Neither argument carries a `default:`. Consuming partials distinguish three states:

| `heading-level` | meaning |
|---|---|
| unset (nil) | inherit a level from the caller, or fall back to the legacy `use-title` boolean |
| `0` | render a `div` |
| `1`–`6` | render `h1`–`h6` |

A `default: 0` would collapse the first two, so `use-title: true` would silently stop producing an `h1`. `InitArgs` omits unset arguments from its result map, which is what keeps the distinction intact.

## Also deliberately no min/max

The args engine supports `options: {min, max}` for `int` and raises an **error** at depth 0. hinode v3.19.0 instead warns and falls back to a `div` for an out-of-range level. Declaring a range here would convert that shipped behaviour into a build failure, and would turn a typo in author front matter into a red build, so this leaves the existing contract alone. Worth deciding separately if the stricter behaviour is preferred.

## Verification

- `hugo -s exampleSite` clean, `node tests/golden.mjs` passes (14 groups).
- Resolved end to end against a hinode branch that reduces `section-title.yml` to release-only overrides (gethinode/hinode#TBD), through a workspace `use`. All six argument shapes render byte-identically to shipped v3.19.0: unset → `div`, `use-title: true` → `h1` with no reset, level 2 → `h2` with the reset, explicit `0` → `div`, level 1 with an empty `heading-class` → `h1` with no extra classes, and level 9 → warns and falls back to `div`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)