### PR TITLE
feat(args): add the filter-responsive argument

### DIFF
--- a/data/structures/_arguments.yml
+++ b/data/structures/_arguments.yml
@@ -560,6 +560,15 @@ arguments:
     comment: >-
       Zero-indexed column number whose text content is matched against the active
       filter value. Defaults to 1. Only used when filter is set.
+  filter-responsive:
+    type: bool
+    optional: true
+    default: false
+    comment: >-
+      Whether the filter button group collapses into a dropdown below the site's
+      main breakpoint, for groups too wide to fit a narrow viewport. Defaults to
+      false, so the button group renders at every width. Only used when filter is
+      set, and has no effect when the main breakpoint is xs.
   fluid:
     type: bool
     optional: true


### PR DESCRIPTION
## Summary

Adds `filter-responsive` to the global argument definitions.

## Why

gethinode/hinode#2137 (released in **v3.22.0**) added `filter-responsive` to the table shortcode, collapsing the filter button group into a dropdown below the site's main breakpoint. It was declared inline in hinode's `data/structures/table.yml`, which is enough while there is one consumer.

mod-blocks' `list` component now forwards the same argument to the table partial. A bookshop blueprint carries no inline types — every key resolves against this file via the snake_case → kebab-case lookup in `ArgsSchema.html`. Without a definition here the build fails hard:

```text
ERROR partial [component-library/components/list/list.hugo.html] - Invalid arguments: components/list.md
        schema: missing type for 'list.filter_responsive'
```

Two consumers, so per the "add to the global file for reusability" guidance the definition belongs here.

## Compatibility

The type matches hinode's inline declaration (`bool`, default `false`), so `ArgsSchema.html` takes the plain merge path rather than the redeclared-type path — the two definitions agree and nothing is dropped. Hinode's inline copy can be removed later as cleanup; it is not required and is already shipped.

Purely additive: a new optional argument defaulting to `false`, so no existing component changes behavior.

## Testing

- `pnpm test` — golden check passed (14 groups), no snapshot movement.
- Verified end-to-end by building mod-blocks' example site against this branch (via `HUGO_MODULE_REPLACEMENTS`) plus hinode v3.22.0: the list component's filter block renders the collapsed dropdown and hides the button group below the breakpoint. Without this branch the same build fails with the error above.

## Blocks

gethinode/mod-blocks — the `list` forward cannot merge until this ships, since its example site would fail to build.
