### PR TITLE
feat(args): add the wrap-cols argument

### DIFF
--- a/data/structures/_arguments.yml
+++ b/data/structures/_arguments.yml
@@ -1718,6 +1718,16 @@ arguments:
     optional: true
     comment: >-
       Toggle the last column to wrap to a new row on smaller devices.
+  wrap-cols:
+    type: string
+    optional: true
+    comment: >-
+      Comma-separated column count per rendered row when wrapping, summing to the
+      table's column count. Folds a record across more than two rows on small
+      devices, for example "2,4,1". Only the first group keeps one cell per
+      column; later groups collapse into a single spanning cell. Requires wrap; a
+      list that does not sum to the column count falls back to wrapping the last
+      column only.
   wrapper:
     type: string
     optional: true


### PR DESCRIPTION
## Summary

Adds `wrap-cols` to the global argument definitions.

## Why

gethinode/hinode#2138 (released in **v3.23.0**) added `wrap-cols` to the table shortcode, folding a record into column groups on small devices rather than moving only its last column. It was declared inline in hinode's `data/structures/table.yml`, which is enough while there is one consumer.

mod-blocks' `list` component now forwards it. A bookshop blueprint carries no inline types — every key resolves against this file via the snake_case → kebab-case lookup in `ArgsSchema.html` — so without a definition here the build fails hard:

```text
ERROR partial [.../list.hugo.html] - Invalid arguments: components/list.md
        schema: missing type for 'list.wrap_cols'
```

Exactly the shape of #365 for `filter-responsive`.

## Compatibility

The type matches hinode's inline declaration (`string`, optional), so `ArgsSchema.html` takes the plain merge path rather than the redeclared-type path. Purely additive: a new optional argument, so no existing component changes behaviour.

## Testing

- `pnpm test` — golden check passed (14 groups), no snapshot movement.
- Verified end-to-end by building mod-blocks' example site against this branch (via `HUGO_MODULE_REPLACEMENTS`) plus hinode v3.23.0: the list component's table emits `data-table-wrap-cols=1,2,1`. Without this branch the same build fails with the error above.

## Blocks

gethinode/mod-blocks — the `list` forward cannot merge until this ships.
